### PR TITLE
Add ContravariantDerivation for cats.Show to examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target
+.jvm
+.js
+.native

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val examples = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(publishSettings: _*)
   .settings(moduleName := "magnolia-examples")
   .settings(quasiQuotesDependencies)
+  .settings(examplesDependencies)
   .nativeSettings(nativeSettings)
   .dependsOn(core)
 
@@ -131,6 +132,9 @@ lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
   libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 )
+
+lazy val examplesDependencies: Seq[Setting[_]] = Seq(
+  libraryDependencies += "org.typelevel" %% "cats-core" % "0.9.0")
 
 credentials ++= (for {
   username <- Option(System.getenv().get("SONATYPE_USERNAME"))

--- a/examples/src/main/scala/cats.scala
+++ b/examples/src/main/scala/cats.scala
@@ -1,0 +1,23 @@
+package magnolia.examples.cats
+
+import scala.collection.immutable.ListMap
+import scala.language.experimental.macros
+import scala.language.higherKinds
+
+import cats.Show
+import magnolia.ContravariantDerivation
+import magnolia.Macros
+
+object instances extends instances1 {
+
+  implicit val showDerivation = new ContravariantDerivation[Show] {
+    type Return = String
+    def call[T](show: Show[T], value: T): String = show.show(value)
+    def construct[T](body: T => String): Show[T] = body(_)
+    def join(xs: ListMap[String, String]): String = xs.map { case (k, v) => s"$k=$v" }.mkString("{", ", ", "}")
+  }
+}
+
+trait instances1 {
+  implicit def genericShow[T]: Show[T] = macro Macros.magnolia[T, Show[_]]
+}

--- a/examples/src/main/scala/example.scala
+++ b/examples/src/main/scala/example.scala
@@ -6,21 +6,11 @@ import language.experimental.macros
 import language.higherKinds
 import collection.immutable.ListMap
 
-object `package` {
-  implicit class Showable[T: Show](t: T) {
-    def show: String = implicitly[Show[T]].show(t)
-  }
-  implicit val showString: Show[String] = identity
-  implicit val showBool: Show[Boolean] = _.toString
-  implicit def showList[T: Show]: Show[List[T]] = xs => xs.map { x => s"list:${implicitly[Show[T]].show(x)}" }.mkString(";")
-  implicit def showSet[T: Show]: Show[Set[T]] = s => "set"
-}
-
 sealed trait EmptyType
 
 sealed trait Tree
 case class Branch(left: Tree, right: Tree) extends Tree
-case class Leaf(value: Int, no: EmptyType) extends Tree
+case class Leaf(value: Int, no: String) extends Tree
 
 sealed trait Entity
 case class Person(name: String, address: Address) extends Entity
@@ -31,11 +21,20 @@ case class Country(name: String, code: String, salesTax: Boolean)
 trait Show[T] { def show(t: T): String }
 object Show extends Show_1 {
   implicit val showInt: Show[Int] = _.toString
+  implicit val showString: Show[String] = identity
+  implicit val showBool: Show[Boolean] = _.toString
+  implicit def showList[T: Show]: Show[List[T]] = xs => xs.map { x => s"list:${implicitly[Show[T]].show(x)}" }.mkString(";")
+  implicit def showSet[T: Show]: Show[Set[T]] = s => "set"
+
   implicit val derivation = new ContravariantDerivation[Show] {
     type Return = String
     def call[T](show: Show[T], value: T): String = show.show(value)
     def construct[T](body: T => String): Show[T] = body(_)
     def join(xs: ListMap[String, String]): String = xs.map { case (k, v) => s"$k=$v" }.mkString("{", ", ", "}")
+  }
+
+  implicit class Showable[T: Show](t: T) {
+    def show: String = implicitly[Show[T]].show(t)
   }
 }
 

--- a/tests/shared/src/main/scala/magnolia/cats.scala
+++ b/tests/shared/src/main/scala/magnolia/cats.scala
@@ -1,0 +1,17 @@
+package magnolia
+
+import examples.{Address, Branch, Country, Entity, Leaf, Person}
+import cats.instances.all._
+import cats.syntax.all._
+import examples.cats.instances._
+import language.experimental.macros
+
+object CatsMain {
+
+  def main(args: Array[String]): Unit = {
+    println(Branch(Branch(Leaf(1, "a"), Leaf(2, "b")), Leaf(3, "c")).show)
+    println(List[Entity](Person("John Smith",
+      Address(List("1 High Street", "London", "SW1A 1AA"),
+        Country("UK", "GBR", false)))).show)
+  }
+}

--- a/tests/shared/src/main/scala/magnolia/main.scala
+++ b/tests/shared/src/main/scala/magnolia/main.scala
@@ -1,10 +1,11 @@
 package magnolia
 
 import examples._
+import examples.Show._
 
 object Main {
   def main(args: Array[String]): Unit = {
-    println(Branch(Branch(Leaf(1, null), Leaf(2, null)), Leaf(3, null)).show)
+    println(Branch(Branch(Leaf(1, "a"), Leaf(2, "b")), Leaf(3, "c")).show)
     println(List[Entity](Person("John Smith",
         Address(List("1 High Street", "London", "SW1A 1AA"),
         Country("UK", "GBR", false)))).show)


### PR DESCRIPTION
Adds the implicits required to derive `cats.Show` type classes to the examples project and also adds a runnable test in the tests project.
