### PR TITLE
Allow type constructor in supertrait

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,10 @@ lazy val publishSettings = Seq(
 
 import java.io.File
 
-lazy val unmanagedSettings = unmanagedBase := (scalaVersion.value.split("\\.").map(_.toInt).to[List] match {
+lazy val unmanagedSettings = unmanagedBase := (scalaVersion.value
+  .split("\\.")
+  .map(_.toInt)
+  .to[List] match {
   case List(2, 12, _) => baseDirectory.value / "lib" / "2.12"
   case List(2, 11, _) => baseDirectory.value / "lib" / "2.11"
 })

--- a/core/src/main/scala/magnolia.scala
+++ b/core/src/main/scala/magnolia.scala
@@ -72,19 +72,19 @@ object Magnolia {
     val arrayCls = tq"_root_.scala.Array"
 
     val prefixType = c.prefix.tree.tpe
-    
+
     val typeDefs = prefixType.baseClasses.flatMap { cls =>
       cls.asType.toType.decls.filter(_.isType).find(_.name.toString == "Typeclass").map { tpe =>
         tpe.asType.toType.asSeenFrom(prefixType, cls)
       }
     }
-    
+
     val typeConstructorOpt =
       typeDefs.headOption.map(_.typeConstructor)
 
     val typeConstructor = typeConstructorOpt.getOrElse {
-      c.abort(c.enclosingPosition, "magnolia: the derivation object does not define the Typeclass "+
-          "type constructor")
+      c.abort(c.enclosingPosition,
+              "magnolia: the derivation object does not define the Typeclass type constructor")
     }
 
     def findType(key: Type): Option[TermName] =
@@ -271,9 +271,9 @@ object Magnolia {
               $paramsVal,
               ($fnVal: Param[$typeConstructor, $genericType] => Any) =>
                 new $genericType(..${caseParams.zipWithIndex.map {
-                  case (typeclass, idx) =>
-                    q"$fnVal($paramsVal($idx)).asInstanceOf[${typeclass.paramType}]"
-                } })
+              case (typeclass, idx) =>
+                q"$fnVal($paramsVal($idx)).asInstanceOf[${typeclass.paramType}]"
+            }})
             ))
           }"""
           )

--- a/examples/src/main/scala/show.scala
+++ b/examples/src/main/scala/show.scala
@@ -10,12 +10,12 @@ import scala.language.experimental.macros
 trait Show[Out, T] { def show(value: T): Out }
 
 trait GenericShow[Out] {
-  
+
   /** the type constructor for new [[Show]] instances
     *
     *  The first parameter is fixed as `String`, and the second parameter varies generically. */
   type Typeclass[T] = Show[Out, T]
- 
+
   def join(typeName: String, strings: Seq[String]): Out
 
   /** creates a new [[Show]] instance by labelling and joining (with `mkString`) the result of

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -55,7 +55,9 @@ object Tests extends TestApp {
 
     test("local implicit beats Magnolia") {
       import magnolia.examples._
-      implicit val showPerson: Show[String, Person] = new Show[String, Person] { def show(p: Person) = "nobody" }
+      implicit val showPerson: Show[String, Person] = new Show[String, Person] {
+        def show(p: Person) = "nobody"
+      }
       implicitly[Show[String, Address]].show(Address("Home", Person("John Smith", 44)))
     }.assert(_ == "Address(line1=Home,occupant=nobody)")
 


### PR DESCRIPTION
The `Typeclass[T]` definition may now be included in a parent class/trait of the derivation object, which means that derivation objects may now be generic in other dimensions.