### PR TITLE
Add minimal testcase for testing functor derivation.

### DIFF
--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -129,6 +129,10 @@ object Tests extends TestApp {
       implicitly[Default[Item]].default
     }.assert(_ == Item("", 1, 0))
 
+    test("functor works as expected") {
+      implicitly[Functor[Tree]].map(Branch(Leaf("Foo"), Leaf("Hello")))(_.length)
+    }.assert(_ == Branch(Leaf(3), Leaf(5)))
+
     test("serialize case object as a sealed trait") {
       implicitly[Show[String, Color]].show(Blue)
     }.assert(_ == "Blue()")


### PR DESCRIPTION
As requested :)

The Functor type class should be something like 
```scala
trait Functor[F[_]] {
  def map[A, B](fa: F[A])(f: A => B): F[B]
}
```

and the manual instance would look something like this:
```scala

implicit val functorTree: Functor[Tree] = new Functor[Tree] {
  def map[A, B](fa: Tree[A])(f: A => B): Tree[B] = fa match {
    case Leaf(a) => Leaf(f(a))
    case Branch(left, right) => Branch(map(left)(f), map(right)(f))
  }
}
```

