### PR TITLE
Add TypeclassCompanion helper trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .jvm
 .js
 .native
+.idea

--- a/core/shared/src/main/scala/TypeclassCompanion.scala
+++ b/core/shared/src/main/scala/TypeclassCompanion.scala
@@ -1,0 +1,25 @@
+package magnolia
+
+import scala.language.experimental.macros
+import scala.language.higherKinds
+
+trait TypeclassCompanion[C[_]] {
+
+  /** Required type constructor for new instances of the typeclass */
+  type Typeclass[T] = C[T]
+
+  /** The typeclass constructor */
+  def apply[T](implicit c: C[T]): C[T] = c
+
+  /** Defines how a typeclass should be constructed for a given case class */
+  def combine[T](ctx: CaseClass[C, T]): C[T]
+
+  /** Defines how to choose which subtype of a sealed trait to use for the
+    * construction of the typeclass
+    * */
+  def dispatch[T](ctx: SealedTrait[C, T]): C[T]
+
+  /** binds the Magnolia macro to the derivation object */
+  implicit def gen[T]: C[T] = macro Magnolia.gen[T]
+
+}

--- a/examples/shared/src/main/scala/decode.scala
+++ b/examples/shared/src/main/scala/decode.scala
@@ -7,7 +7,7 @@ import scala.language.experimental.macros
 trait Decoder[T] { def decode(str: String): T }
 
 /** derivation object (and companion object) for [[Decoder]] instances */
-object Decoder {
+object Decoder extends TypeclassCompanion[Decoder] {
 
   /** decodes strings */
   implicit val string: Decoder[String] = new Decoder[String] {
@@ -16,12 +16,6 @@ object Decoder {
 
   /** decodes ints */
   implicit val int: Decoder[Int] = new Decoder[Int] { def decode(str: String): Int = str.toInt }
-
-  /** binds the Magnolia macro to this derivation object */
-  implicit def gen[T]: Decoder[T] = macro Magnolia.gen[T]
-
-  /** type constructor for new instances of the typeclass */
-  type Typeclass[T] = Decoder[T]
 
   /** defines how new [[Decoder]]s for case classes should be constructed */
   def combine[T](ctx: CaseClass[Decoder, T]): Decoder[T] = new Decoder[T] {

--- a/examples/shared/src/main/scala/default.scala
+++ b/examples/shared/src/main/scala/default.scala
@@ -7,9 +7,7 @@ import scala.language.experimental.macros
 trait Default[T] { def default: T }
 
 /** companion object and derivation object for [[Default]] */
-object Default {
-
-  type Typeclass[T] = Default[T]
+object Default extends TypeclassCompanion[Default] {
 
   /** constructs a default for each parameter, using the constructor default (if provided),
     *  otherwise using a typeclass-provided default */
@@ -20,7 +18,7 @@ object Default {
   }
 
   /** chooses which subtype to delegate to */
-  def dispatch[T](ctx: SealedTrait[Default, T])(): Default[T] = new Default[T] {
+  def dispatch[T](ctx: SealedTrait[Default, T]): Default[T] = new Default[T] {
     def default: T = ctx.subtypes.head.typeclass.default
   }
 
@@ -29,7 +27,4 @@ object Default {
 
   /** default value for ints; 0 */
   implicit val int: Default[Int] = new Default[Int] { def default = 0 }
-
-  /** generates default instances of [[Default]] for case classes and sealed traits */
-  implicit def gen[T]: Default[T] = macro Magnolia.gen[T]
 }

--- a/examples/shared/src/main/scala/eq.scala
+++ b/examples/shared/src/main/scala/eq.scala
@@ -7,10 +7,7 @@ import scala.language.experimental.macros
 trait Eq[T] { def equal(value: T, value2: T): Boolean }
 
 /** companion object to [[Eq]] */
-object Eq {
-
-  /** type constructor for the equality typeclass */
-  type Typeclass[T] = Eq[T]
+object Eq extends TypeclassCompanion[Eq] {
 
   /** defines equality for this case class in terms of equality for all its parameters */
   def combine[T](ctx: CaseClass[Eq, T]): Eq[T] = new Eq[T] {
@@ -36,6 +33,4 @@ object Eq {
   /** equality typeclass instance for integers */
   implicit val int: Eq[Int] = new Eq[Int] { def equal(v1: Int, v2: Int) = v1 == v2 }
 
-  /** binds the Magnolia macro to the `gen` method */
-  implicit def gen[T]: Eq[T] = macro Magnolia.gen[T]
 }

--- a/examples/shared/src/main/scala/show.scala
+++ b/examples/shared/src/main/scala/show.scala
@@ -9,12 +9,10 @@ import scala.language.experimental.macros
   *  be something other than a string. */
 trait Show[Out, T] { def show(value: T): Out }
 
-trait GenericShow[Out] {
-
-  /** the type constructor for new [[Show]] instances
-    *
-    *  The first parameter is fixed as `String`, and the second parameter varies generically. */
-  type Typeclass[T] = Show[Out, T]
+/**
+  * For the present example, a type lambda was needed to use the TypeclassCompanion
+  */
+trait GenericShow[Out] extends TypeclassCompanion[({type S[A] = Show[Out, A]})#S]{
 
   def join(typeName: String, strings: Seq[String]): Out
 
@@ -40,13 +38,12 @@ trait GenericShow[Out] {
       sub.typeclass.show(sub.cast(value))
     }
   }
-
-  /** bind the Magnolia macro to this derivation object */
-  implicit def gen[T]: Show[Out, T] = macro Magnolia.gen[T]
 }
 
 /** companion object to [[Show]] */
 object Show extends GenericShow[String] {
+
+  type S[A] = Show[String, A]
 
   /** show typeclass for strings */
   implicit val string: Show[String, String] = new Show[String, String] {


### PR DESCRIPTION
Adds the `TypeclassCompanion` helper trait that defines the properties needed for the derivation macro to work

```scala
import scala.language.experimental.macros
import scala.language.higherKinds

trait TypeclassCompanion[C[_]] {

  /** Required type constructor for new instances of the typeclass */
  type Typeclass[T] = C[T]

  /** The typeclass constructor */
  def apply[T](implicit c: C[T]): C[T] = c

  /** Defines how a typeclass should be constructed for a given case class */
  def combine[T](ctx: CaseClass[C, T]): C[T]

  /** Defines how to choose which subtype of a sealed trait to use for the
    * construction of the typeclass
    * */
  def dispatch[T](ctx: SealedTrait[C, T]): C[T]

  /** binds the Magnolia macro to the derivation object */
  implicit def gen[T]: C[T] = macro Magnolia.gen[T]

}
```

How it works is shown in the updated examples.