### PR TITLE
Move pathedCompanionRef to a GlobalUtil object

### DIFF
--- a/core/shared/src/main/scala/globalutil.scala
+++ b/core/shared/src/main/scala/globalutil.scala
@@ -1,0 +1,59 @@
+package magnolia
+
+import scala.reflect.macros.{runtime, whitebox}
+import scala.tools.nsc.Global
+
+/** Workarounds that needs to use `nsc.Global`. */
+private[magnolia] object GlobalUtil {
+
+  // From Shapeless: https://github.com/milessabin/shapeless/blob/master/core/src/main/scala/shapeless/generic.scala#L698
+  // Cut-n-pasted (with most original comments) and slightly adapted from
+  // https://github.com/scalamacros/paradise/blob/c14c634923313dd03f4f483be3d7782a9b56de0e/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Namers.scala#L568-L613
+  def patchedCompanionRef(c: whitebox.Context)(tpe: c.Type): c.Tree = {
+    // see https://github.com/scalamacros/paradise/issues/7
+    // also see https://github.com/scalamacros/paradise/issues/64
+
+    val global = c.universe.asInstanceOf[Global]
+    val typer = c.asInstanceOf[runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
+    val ctx = typer.context
+    val globalType = tpe.asInstanceOf[global.Type]
+    val original = globalType.typeSymbol
+    val owner = original.owner
+    val companion = original.companion.orElse {
+      import global.{ abort => aabort, _ }
+      implicit class PatchedContext(ctx: global.analyzer.Context) {
+        trait PatchedLookupResult { def suchThat(criterion: Symbol => Boolean): Symbol }
+        def patchedLookup(name: Name, expectedOwner: Symbol) = new PatchedLookupResult {
+          override def suchThat(criterion: Symbol => Boolean): Symbol = {
+            var res: Symbol = NoSymbol
+            var ctx = PatchedContext.this.ctx
+            while (res == NoSymbol && ctx.outer != ctx) {
+              // NOTE: original implementation says `val s = ctx.scope lookup name`
+              // but we can't use it, because Scope.lookup returns wrong results when the lookup is ambiguous
+              // and that triggers https://github.com/scalamacros/paradise/issues/64
+              val s = {
+                val lookupResult = ctx.scope.lookupAll(name).filter(criterion).toList
+                lookupResult match {
+                  case Nil => NoSymbol
+                  case List(unique) => unique
+                  case _ => aabort(s"unexpected multiple results for a companion symbol lookup for $original#{$original.id}")
+                }
+              }
+              if (s != NoSymbol && s.owner == expectedOwner)
+                res = s
+              else
+                ctx = ctx.outer
+            }
+            res
+          }
+        }
+      }
+
+      ctx.patchedLookup(original.name.companionName, owner) suchThat { sym =>
+        (original.isTerm || sym.hasModuleFlag) && (sym isCoDefinedWith original)
+      }
+    }
+
+    global.gen.mkAttributedRef(globalType.prefix, companion).asInstanceOf[c.Tree]
+  }
+}

--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -75,15 +75,6 @@ object Magnolia {
 
     val prefixType = c.prefix.tree.tpe
 
-    def companionRef(tpe: Type): Tree = {
-      val global = c.universe match { case global: scala.tools.nsc.Global => global }
-      val globalTpe = tpe.asInstanceOf[global.Type]
-      val companion = globalTpe.typeSymbol.companionSymbol
-      if (companion != NoSymbol)
-        global.gen.mkAttributedRef(globalTpe.prefix, companion).asInstanceOf[Tree]
-      else q"${tpe.typeSymbol.name.toTermName}"
-    }
-
     val typeDefs = prefixType.baseClasses.flatMap { cls =>
       cls.asType.toType.decls.filter(_.isType).find(_.name.toString == "Typeclass").map { tpe =>
         tpe.asType.toType.asSeenFrom(prefixType, cls)
@@ -201,56 +192,6 @@ object Magnolia {
       }
     }
 
-    // From Shapeless: https://github.com/milessabin/shapeless/blob/master/core/src/main/scala/shapeless/generic.scala#L698
-    // Cut-n-pasted (with most original comments) and slightly adapted from
-    // https://github.com/scalamacros/paradise/blob/c14c634923313dd03f4f483be3d7782a9b56de0e/plugin/src/main/scala/org/scalamacros/paradise/typechecker/Namers.scala#L568-L613
-    def patchedCompanionSymbolOf(original: c.Symbol): c.Symbol = {
-      // see https://github.com/scalamacros/paradise/issues/7
-      // also see https://github.com/scalamacros/paradise/issues/64
-
-      val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-      val typer = c.asInstanceOf[scala.reflect.macros.runtime.Context].callsiteTyper.asInstanceOf[global.analyzer.Typer]
-      val ctx = typer.context
-      val owner = original.owner
-
-      import global.analyzer.Context
-
-      original.companion.orElse {
-        import global.{ abort => aabort, _ }
-        implicit class PatchedContext(ctx: Context) {
-          trait PatchedLookupResult { def suchThat(criterion: Symbol => Boolean): Symbol }
-          def patchedLookup(name: Name, expectedOwner: Symbol) = new PatchedLookupResult {
-            override def suchThat(criterion: Symbol => Boolean): Symbol = {
-              var res: Symbol = NoSymbol
-              var ctx = PatchedContext.this.ctx
-              while (res == NoSymbol && ctx.outer != ctx) {
-                // NOTE: original implementation says `val s = ctx.scope lookup name`
-                // but we can't use it, because Scope.lookup returns wrong results when the lookup is ambiguous
-                // and that triggers https://github.com/scalamacros/paradise/issues/64
-                val s = {
-                  val lookupResult = ctx.scope.lookupAll(name).filter(criterion).toList
-                  lookupResult match {
-                    case Nil => NoSymbol
-                    case List(unique) => unique
-                    case _ => aabort(s"unexpected multiple results for a companion symbol lookup for $original#{$original.id}")
-                  }
-                }
-                if (s != NoSymbol && s.owner == expectedOwner)
-                  res = s
-                else
-                  ctx = ctx.outer
-              }
-              res
-            }
-          }
-        }
-        ctx.patchedLookup(original.asInstanceOf[global.Symbol].name.companionName, owner.asInstanceOf[global.Symbol]).suchThat(sym =>
-          (original.isTerm || sym.hasModuleFlag) &&
-            (sym isCoDefinedWith original.asInstanceOf[global.Symbol])
-        ).asInstanceOf[c.universe.Symbol]
-      }
-    }
-
     def directInferImplicit(genericType: c.Type, typeConstructor: Type): Option[Typeclass] = {
 
       val genericTypeName: String = genericType.typeSymbol.name.decodedName.toString.toLowerCase
@@ -278,8 +219,7 @@ object Magnolia {
       val className = s"${genericType.typeSymbol.owner.fullName}.${genericType.typeSymbol.name.decodedName}"
 
       val result = if (isCaseObject) {
-        val obj = companionRef(genericType)
-
+        val obj = GlobalUtil.patchedCompanionRef(c)(genericType)
         val impl = q"""
           ${c.prefix}.combine($magnoliaPkg.Magnolia.caseClass[$typeConstructor, $genericType](
             $className, true, false, new $scalaPkg.Array(0), _ => $obj)
@@ -338,12 +278,13 @@ object Magnolia {
         val preAssignments = caseParams.map(_.typeclass)
 
         val defaults = if (!isValueClass) {
-          val caseClassCompanion = patchedCompanionSymbolOf(genericType.typeSymbol).asModule.info
+          val companionRef = GlobalUtil.patchedCompanionRef(c)(genericType)
+          val companionSym = companionRef.symbol.asModule.info
 
           // If a companion object is defined with alternative apply methods
           // it is needed get all the alternatives
           val constructorMethods =
-            caseClassCompanion.decl(TermName("apply")).alternatives.map(_.asMethod)
+          companionSym.decl(TermName("apply")).alternatives.map(_.asMethod)
 
           // The last apply method in the alternatives is the one that belongs
           // to the case class, not the user defined companion object
@@ -354,7 +295,7 @@ object Magnolia {
             case (p, idx) =>
               if (p.isParamWithDefault) {
                 val method = TermName("apply$default$" + (idx + 1))
-                q"$scalaPkg.Some(${genericType.typeSymbol.companion.asTerm}.$method)"
+                q"$scalaPkg.Some($companionRef.$method)"
               } else q"$scalaPkg.None"
           }
         } else List(q"$scalaPkg.None")

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -63,7 +63,7 @@ case class Portfolio(companies: Company*)
 
 object Tests extends TestApp {
 
-  def tests() = for (i <- 1 to 1) {
+  def tests(): Unit = for (i <- 1 to 1) {
     import examples._
 
     test("construct a Show product instance with alternative apply functions") {
@@ -237,21 +237,37 @@ object Tests extends TestApp {
         |""")
     }
 
-    class ParentClass() {
-      case class LocalClass(name: String)
+    class ParentClass {
+      case class InnerClass(name: String)
+      case class InnerClassWithDefault(name: String = "foo")
 
-      test("serialize a case class inside another class") {
-        implicitly[Show[String, LocalClass]].show(LocalClass("foo"))
-      }.assert(_ == "LocalClass(name=foo)")
+      def testInner(): Unit = {
+        test("serialize a case class inside another class") {
+          implicitly[Show[String, InnerClass]].show(InnerClass("foo"))
+        }.assert(_ == "InnerClass(name=foo)")
 
-      case class LocalClassWithDefault(name: String = "foo")
+        test("construct a default case class inside another class") {
+          Default.gen[InnerClassWithDefault].default
+        }.assert(_ == InnerClassWithDefault("foo"))
+      }
 
-      test("construct a default case class inside another class") {
-        Default.gen[LocalClassWithDefault].default
-      }.assert(_ == LocalClassWithDefault("foo"))
+      def testLocal(): Unit = {
+        case class LocalClass(name: String)
+        case class LocalClassWithDefault(name: String = "foo")
+
+        test("serialize a case class inside a method") {
+          implicitly[Show[String, LocalClass]].show(LocalClass("foo"))
+        }.assert(_ == "LocalClass(name=foo)")
+
+        test("construct a default case class inside a method") {
+          Default.gen[LocalClassWithDefault].default
+        }.assert(_ == LocalClassWithDefault("foo"))
+      }
     }
     
-    new ParentClass()
+    val parent = new ParentClass
+    parent.testInner()
+    parent.testLocal()
 
     test("show an Account") {
       Show.gen[Account].show(Account("john_doe", "john.doe@yahoo.com", "john.doe@gmail.com"))
@@ -273,6 +289,5 @@ object Tests extends TestApp {
       implicit val stringTypeName: TypeName[String] = new TypeName[String] { def name = "" }
       TypeName.gen[Fruit].name
     }.assert(_ == "magnolia.tests.Fruit")
-    ()
   }
 }


### PR DESCRIPTION
That method is a workaround for a bug.
It doesn't belong in the core Magnolia macro. Also:
 * Use `patchedCompanionRef` consistently
 * Add a test for the workaround (method-local classes)

Follow up #39 it was merged before I could explain what I actually meant by local classes :smile: 