### PR TITLE
Fix regression introduced by move to `patchedCompanionRef`

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -225,11 +225,10 @@ object Magnolia {
       }
 
       val result = if (isCaseObject) {
-        val obj = GlobalUtil.patchedCompanionRef(c)(genericType)
         val impl = q"""
           $typeNameDef
           ${c.prefix}.combine($magnoliaPkg.Magnolia.caseClass[$typeConstructor, $genericType](
-            $typeName, true, false, new $scalaPkg.Array(0), _ => $obj)
+            $typeName, true, false, new $scalaPkg.Array(0), _ => ${genericType.typeSymbol.asClass.module})
           )
         """
         Some(Typeclass(genericType, impl))

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -318,6 +318,10 @@ object Tests extends TestApp {
     test("show a Portfolio of Companies") {
       Show.gen[Portfolio].show(Portfolio(Company("Alice Inc"), Company("Bob & Co")))
     }.assert(_ == "Portfolio(companies=[Company(name=Alice Inc),Company(name=Bob & Co)])")
+
+    test("show a List[Int]") {
+      Show.gen[List[Int]].show(List(1, 2, 3))
+    }.assert(_ == "::(head=1,tl$access$1=::(head=2,tl$access$1=::(head=3,tl$access$1=Nil())))")
     
     test("sealed trait typeName should be complete and unchanged") {
       TypeNameInfo.gen[Color].name


### PR DESCRIPTION
[This commit](https://github.com/propensive/magnolia/commit/c91b7cac849237062eea8a75134783e826dc21a0) introduced a regression that broke things like `Show.gen[List[Int]]`.

This patch selectively rolls back the changes from that commit, which green-lights the added test.

I have to say that I have absolutely no insight whatsoever into the intricacies of the name resolution here, so a proper review by @propensive and @joroKr21 is probably of the essence.