### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: scala
 
 before_install:
-- curl https://raw.githubusercontent.com/scala-native/scala-native/9069e8d447f7a9a5439bffbb6a706b5cc70bd631/bin/travis_setup.sh | bash -x
+- curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
       
 script:
   - sbt +compile +tests/run


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.