### PR TITLE
Make Deferred public (but compileTimeOnly)

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -14,6 +14,7 @@
  */
 package magnolia
 
+import scala.collection.breakOut
 import scala.collection.mutable
 import scala.language.existentials
 import scala.language.higherKinds
@@ -519,17 +520,10 @@ private[magnolia] object CompileTimeState {
     }
 
     def trace: List[TypePath] =
-      frames
-        .drop(1)
-        .foldLeft[(C#Type, List[TypePath])]((null, Nil)) {
-          case ((_, Nil), frame) =>
-            (frame.searchType, frame.path :: Nil)
-          case (continue @ (tpe, acc), frame) =>
-            if (tpe =:= frame.searchType) continue
-            else (frame.searchType, frame.path :: acc)
-        }
-        ._2
-        .reverse
+      (frames.drop(1), frames).zipped.collect {
+        case (Frame(path, tp1, _), Frame(_, tp2, _))
+          if !(tp1 =:= tp2) => path
+      } (breakOut)
 
     override def toString: String =
       frames.mkString("magnolia stack:\n", "\n", "\n")

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -43,10 +43,10 @@ class Length(val value: Int) extends AnyVal
 
 case class FruitBasket(fruits: Fruit*)
 case class Lunchbox(fruit: Fruit, drink: String)
+case class Fruit(name: String)
 object Fruit {
   implicit val showFruit: Show[String, Fruit] = (f: Fruit) => f.name
 }
-case class Fruit(name: String)
 
 case class Item(name: String, quantity: Int = 1, price: Int)
 
@@ -116,19 +116,16 @@ object Tests extends TestApp {
     }.assert(_ == "Address(line1=Home,occupant=nobody)")
 
     test("even low-priority implicit beats Magnolia for nested case") {
-      import Show.gen
       implicitly[Show[String, Lunchbox]].show(Lunchbox(Fruit("apple"), "lemonade"))
     }.assert(_ == "Lunchbox(fruit=apple,drink=lemonade)")
 
-    test("low-priority implicit does not beat Magnolia when not nested") {
-      import Show.gen
+    test("low-priority implicit beats Magnolia when not nested") {
       implicitly[Show[String, Fruit]].show(Fruit("apple"))
-    }.assert(_ == "Fruit(name=apple)")
+    }.assert(_ == "apple")
 
-    test("low-priority implicit does not beat Magnolia when chained") {
-      import Show.gen
+    test("low-priority implicit beats Magnolia when chained") {
       implicitly[Show[String, FruitBasket]].show(FruitBasket(Fruit("apple"), Fruit("banana")))
-    }.assert(_ == "FruitBasket(fruits=[Fruit(name=apple),Fruit(name=banana)])")
+    }.assert(_ == "FruitBasket(fruits=[apple,banana])")
 
     test("typeclass implicit scope has lower priority than ADT implicit scope") {
       implicitly[Show[String, Fruit]].show(Fruit("apple"))


### PR DESCRIPTION
It is required for the type checking of recursive typeclasses.

Including some test clarifications and minor improvements of the implementation
(look at individual commit messages).

fixes #87 

Unfortunately to verify this we would need to add a test that is not in the `magnolia` package.
Let me know if and how to do that if necessary.