### PR TITLE
Use encodedName to avoid invalid identifier names

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -101,7 +101,7 @@ object Magnolia {
     def knownSubclasses(sym: ClassSymbol): List[Symbol] = {
       val children = sym.knownDirectSubclasses.toList
       val (abstractTypes, concreteTypes) = children.partition(_.isAbstract)
-      
+
       abstractTypes.map(_.asClass).flatMap(knownSubclasses(_)) ::: concreteTypes
     }
 
@@ -167,7 +167,7 @@ object Magnolia {
 
     def directInferImplicit(genericType: Type, typeConstructor: Type): Option[Tree] = {
       val genericTypeName = genericType.typeSymbol.name.decodedName.toString.toLowerCase
-      val assignedName = TermName(c.freshName(s"${genericTypeName}Typeclass"))
+      val assignedName = TermName(c.freshName(s"${genericTypeName}Typeclass")).encodedName.toTermName
       val typeSymbol = genericType.typeSymbol
       val classType = if (typeSymbol.isClass) Some(typeSymbol.asClass) else None
       val isCaseClass = classType.exists(_.isCaseClass)
@@ -313,7 +313,7 @@ object Magnolia {
             ..$assignments
 
             $typeNameDef
-            
+
             ${c.prefix}.combine($magnoliaPkg.Magnolia.caseClass[$typeConstructor, $genericType](
               $typeName,
               false,
@@ -374,11 +374,11 @@ object Magnolia {
         Some(q"""{
             val $subtypesVal: $scalaPkg.Array[$magnoliaPkg.Subtype[$typeConstructor, $genericType]] =
               new $scalaPkg.Array(${assignments.size})
-            
+
             ..$assignments
 
             $typeNameDef
-            
+
             ${c.prefix}.dispatch(new $magnoliaPkg.SealedTrait(
               $typeName,
               $subtypesVal: $scalaPkg.Array[$magnoliaPkg.Subtype[$typeConstructor, $genericType]],


### PR DESCRIPTION
Fixes #101