### PR TITLE
Use strict vals by default and fall back to lazy vals

### DIFF
--- a/examples/shared/src/main/scala/csv.scala
+++ b/examples/shared/src/main/scala/csv.scala
@@ -1,0 +1,29 @@
+package magnolia.examples
+
+import magnolia._
+import scala.language.experimental.macros
+
+trait Csv[A] {
+  def apply(a: A): List[String]
+}
+
+object Csv {
+  type Typeclass[A] = Csv[A]
+
+  def combine[A](ctx: CaseClass[Csv, A]): Csv[A] = new Csv[A] {
+    def apply(a: A): List[String] =
+      ctx.parameters.foldLeft(List[String]()) {
+        (acc, p) => acc ++ p.typeclass(p.dereference(a))
+      }
+  }
+
+  def dispatch[A](ctx: SealedTrait[Csv, A]): Csv[A] = new Csv[A] {
+    def apply(a: A): List[String] = ctx.dispatch(a)(sub => sub.typeclass(sub.cast(a)))
+  }
+
+  implicit def deriveCsv[A]: Csv[A] = macro Magnolia.gen[A]
+
+  implicit val csvStr: Csv[String] = new Csv[String] {
+    def apply(a: String): List[String] = List(a)
+  }
+}

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -88,6 +88,10 @@ case class Portfolio(companies: Company*)
 
 case class Recursive(children: Seq[Recursive])
 
+// This tests compilation.
+class GenericCsv[A: Csv]
+object ParamCsv extends GenericCsv[Param]
+
 object Tests extends TestApp {
 
   def tests(): Unit = for (_ <- 1 to 1) {

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -385,7 +385,7 @@ object Tests extends TestApp {
       scalac"""
         WeakHash.gen[Person]
       """
-    }.assert(_ == Returns(fqt"magnolia.examples.WeakHash.Typeclass[magnolia.tests.Person]"))
+    }.assert(_ == Returns(fqt"magnolia.examples.WeakHash[magnolia.tests.Person]"))
     
     test("disallow coproduct derivations without dispatch method") {
       scalac"""


### PR DESCRIPTION
when subtrees are Deferred or reference enclosing vals.