### PR TITLE
checkMethod: termName is not used in the error message

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -123,7 +123,7 @@ object Magnolia {
 
       val firstParamBlock = combineClass.asType.toType.decl(term).asTerm.asMethod.paramLists.head
       if (firstParamBlock.lengthCompare(1) != 0)
-        error(s"magnolia: the method `combine` should take a single parameter of type $expected")
+        error(s"magnolia: the method `$termName` should take a single parameter of type $expected")
     }
 
     checkMethod("combine", "case classes", "CaseClass[Typeclass, _]")


### PR DESCRIPTION
Method `checkMethod` is not using `termName` in the error message.