### PR TITLE
semiauto derivation if gen is not implicit

### DIFF
--- a/core/shared/src/main/scala/interface.scala
+++ b/core/shared/src/main/scala/interface.scala
@@ -160,7 +160,7 @@ abstract class CaseClass[Typeclass[_], Type] private[magnolia] (
    *
    * @see construct
    */
-  final def constructEither[E <: AnyRef, Return](makeParam: Param[Typeclass, Type] => Either[E, Return]): Either[E, Type] = {
+  final def constructEither[E, Return](makeParam: Param[Typeclass, Type] => Either[E, Return]): Either[E, Type] = {
     // poor man's scalaz.Traverse
     try {
       Right(

--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -136,6 +136,10 @@ object Magnolia {
 
     val fullauto = c.macroApplication.symbol.isImplicit
 
+    // halp! I really just want to ask "is t a subtype of T?"
+    def halfauto(s: Type): Boolean =
+      s.typeSymbol.isClass && s.typeSymbol.asClass.baseClasses.contains(weakTypeOf[T].typeSymbol)
+
     val expandDeferred = new Transformer {
       override def transform(tree: Tree) = tree match {
         case q"$magnolia.Deferred.apply[$_](${Literal(Constant(method: String))})"
@@ -170,7 +174,8 @@ object Magnolia {
           Option(c.inferImplicitValue(searchType))
             .filterNot(_.isEmpty)
             .orElse(
-              if (fullauto) directInferImplicit(genericType, typeConstructor)
+              if (fullauto || halfauto(genericType))
+                directInferImplicit(genericType, typeConstructor)
               else None
             )
             .getOrElse {

--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -39,6 +39,9 @@ object Magnolia {
     *  `Derivation.gen[T]` or with `implicitly[Typeclass[T]]`, if the implicit method is imported
     *  into the current scope.
     *
+    *  If the `gen` is not `implicit`, semi-auto derivation is used instead, whereby implicits will
+    *  not be generated outside of this ADT.
+    *
     *  The definition expects a type constructor called `Typeclass`, taking one *-kinded type
     *  parameter to be defined on the same object as a means of determining how the typeclass should
     *  be genericized. While this may be obvious for typeclasses like `Show[T]` which take only a

--- a/examples/shared/src/main/scala/semiauto.scala
+++ b/examples/shared/src/main/scala/semiauto.scala
@@ -7,6 +7,8 @@ trait SemiDefault[A] {
   def default: A
 }
 object SemiDefault {
+  @inline def apply[A](implicit A: SemiDefault[A]): SemiDefault[A] = A
+
   type Typeclass[T] = SemiDefault[T]
 
   def combine[T](ctx: CaseClass[SemiDefault, T]): SemiDefault[T] = new SemiDefault[T] {

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -98,7 +98,8 @@ class NotDerivable
 
 case class NoDefault(value: Boolean)
 
-final case class ServiceName(value: String) extends AnyVal
+final case class ServiceName1(value: String) extends AnyVal
+final case class ServiceName2(value: String)
 
 object Tests extends TestApp {
 
@@ -224,15 +225,37 @@ object Tests extends TestApp {
         |    in parameter 'unit' of product type Gamma
         |"""))
 
-    test("not assume full auto derivation") {
+    test("not assume full auto derivation of external value classes") {
       scalac"""
-        case class LoggingConfig(n: ServiceName, o: Option[String])
+        case class LoggingConfig(n: ServiceName1)
         object LoggingConfig {
           implicit val semi: SemiDefault[LoggingConfig] = SemiDefault.gen
         }
         """
-    }.assert(_ == TypecheckError(txt"""magnolia: could not find SemiDefault.Typeclass for type magnolia.tests.ServiceName
+    }.assert(_ == TypecheckError(txt"""magnolia: could not find SemiDefault.Typeclass for type magnolia.tests.ServiceName1
     in parameter 'n' of product type LoggingConfig
+""") )
+
+    test("not assume full auto derivation of external products") {
+      scalac"""
+        case class LoggingConfig(n: ServiceName2)
+        object LoggingConfig {
+          implicit val semi: SemiDefault[LoggingConfig] = SemiDefault.gen
+        }
+        """
+    }.assert(_ == TypecheckError(txt"""magnolia: could not find SemiDefault.Typeclass for type magnolia.tests.ServiceName2
+    in parameter 'n' of product type LoggingConfig
+""") )
+
+    test("not assume full auto derivation of external coproducts") {
+      scalac"""
+        case class LoggingConfig(o: Option[String])
+        object LoggingConfig {
+          implicit val semi: SemiDefault[LoggingConfig] = SemiDefault.gen
+        }
+        """
+    }.assert(_ == TypecheckError(txt"""magnolia: could not find SemiDefault.Typeclass for type Option[String]
+    in parameter 'o' of product type LoggingConfig
 """) )
 
     test("typenames and labels are not encoded") {

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -101,6 +101,10 @@ case class NoDefault(value: Boolean)
 final case class ServiceName1(value: String) extends AnyVal
 final case class ServiceName2(value: String)
 
+sealed abstract class Halfy
+final case class Lefty() extends Halfy
+final case class Righty() extends Halfy
+
 object Tests extends TestApp {
 
   def tests(): Unit = for (_ <- 1 to 1) {
@@ -257,6 +261,10 @@ object Tests extends TestApp {
     }.assert(_ == TypecheckError(txt"""magnolia: could not find SemiDefault.Typeclass for type Option[String]
     in parameter 'o' of product type LoggingConfig
 """) )
+
+    test("half auto derivation of sealed families") {
+      SemiDefault.gen[Halfy].default
+    }.assert(_ == Lefty())
 
     test("typenames and labels are not encoded") {
       implicitly[Show[String, `%%`]].show(`%%`(1, "two"))


### PR DESCRIPTION
The motivation for this PR is that it allows one to derive an ADT but without it escaping into other people's types. Combined with the `@deriving` annotation it means we can write this

```scala
@deriving(Show, Equal, Arbitrary)
sealed abstract class JsValue
final case object JsNull                                    extends JsValue
final case class JsObject(fields: IList[(String, JsValue)]) extends JsValue
final case class JsArray(elements: IList[JsValue])          extends JsValue
final case class JsBoolean(value: Boolean)                  extends JsValue
final case class JsString(value: String)                    extends JsValue
final case class JsDouble(value: Double)                    extends JsValue
final case class JsInteger(value: Long)                     extends JsValue
```

instead of having to derive for all the products individually (and making their instances visible!)

```scala
@deriving(Show, Arbitrary)
final case object JsNull extends JsValue
@deriving(Show, Arbitrary)
final case class JsObject(fields: IList[(String, JsValue)]) extends JsValue
@deriving(Show, Arbitrary)
final case class JsArray(elements: IList[JsValue]) extends JsValue
@deriving(Show, Arbitrary)
final case class JsBoolean(value: Boolean) extends JsValue
@deriving(Show, Arbitrary)
final case class JsString(value: String) extends JsValue
@deriving(Show, Arbitrary)
final case class JsDouble(value: Double) extends JsValue
@deriving(Show, Arbitrary)
final case class JsInteger(value: Long) extends JsValue
```