### PR TITLE
Rename confusing default in example

### DIFF
--- a/examples/shared/src/main/scala/default.scala
+++ b/examples/shared/src/main/scala/default.scala
@@ -18,16 +18,16 @@ import magnolia._, mercator._
 import scala.language.experimental.macros
 
 /** typeclass for providing a default value for a particular type */
-trait Default[T] { def defaultValue: Either[String, T] }
+trait HasDefault[T] { def defaultValue: Either[String, T] }
 
-/** companion object and derivation object for [[Default]] */
-object Default {
+/** companion object and derivation object for [[HasDefault]] */
+object HasDefault {
 
-  type Typeclass[T] = Default[T]
+  type Typeclass[T] = HasDefault[T]
 
   /** constructs a default for each parameter, using the constructor default (if provided),
     *  otherwise using a typeclass-provided default */
-  def combine[T](ctx: CaseClass[Default, T]): Default[T] = new Default[T] {
+  def combine[T](ctx: CaseClass[HasDefault, T]): HasDefault[T] = new HasDefault[T] {
     def defaultValue = ctx.constructMonadic { param =>
       param.default match {
         case Some(arg) => Right(arg)
@@ -37,7 +37,7 @@ object Default {
   }
 
   /** chooses which subtype to delegate to */
-  def dispatch[T](ctx: SealedTrait[Default, T])(): Default[T] = new Default[T] {
+  def dispatch[T](ctx: SealedTrait[HasDefault, T])(): HasDefault[T] = new HasDefault[T] {
     def defaultValue = ctx.subtypes.headOption match {
       case Some(sub) => sub.typeclass.defaultValue
       case None => Left("no subtypes")
@@ -45,17 +45,17 @@ object Default {
   }
 
   /** default value for a string; the empty string */
-  implicit val string: Default[String] = new Default[String] { def defaultValue = Right("") }
+  implicit val string: HasDefault[String] = new HasDefault[String] { def defaultValue = Right("") }
 
   /** default value for ints; 0 */
-  implicit val int: Default[Int] = new Default[Int] { def defaultValue = Right(0) }
+  implicit val int: HasDefault[Int] = new HasDefault[Int] { def defaultValue = Right(0) }
 
   /** oh, no, there is no default Boolean... whatever will we do? */
-  implicit val boolean: Default[Boolean] = new Default[Boolean] { def defaultValue = Left("truth is a lie") }
+  implicit val boolean: HasDefault[Boolean] = new HasDefault[Boolean] { def defaultValue = Left("truth is a lie") }
 
   /** default value for sequences; the empty sequence */
-  implicit def seq[A]: Default[Seq[A]] = new Typeclass[Seq[A]] { def default = Right(Seq.empty) }
+  implicit def seq[A]: HasDefault[Seq[A]] = new Typeclass[Seq[A]] { def default = Right(Seq.empty) }
 
-  /** generates default instances of [[Default]] for case classes and sealed traits */
-  implicit def gen[T]: Default[T] = macro Magnolia.gen[T]
+  /** generates default instances of [[HasDefault]] for case classes and sealed traits */
+  implicit def gen[T]: HasDefault[T] = macro Magnolia.gen[T]
 }

--- a/examples/shared/src/main/scala/default.scala
+++ b/examples/shared/src/main/scala/default.scala
@@ -18,7 +18,7 @@ import magnolia._, mercator._
 import scala.language.experimental.macros
 
 /** typeclass for providing a default value for a particular type */
-trait Default[T] { def default: Either[String, T] }
+trait Default[T] { def defaultValue: Either[String, T] }
 
 /** companion object and derivation object for [[Default]] */
 object Default {
@@ -28,30 +28,30 @@ object Default {
   /** constructs a default for each parameter, using the constructor default (if provided),
     *  otherwise using a typeclass-provided default */
   def combine[T](ctx: CaseClass[Default, T]): Default[T] = new Default[T] {
-    def default = ctx.constructMonadic { param =>
+    def defaultValue = ctx.constructMonadic { param =>
       param.default match {
         case Some(arg) => Right(arg)
-        case None => param.typeclass.default
+        case None => param.typeclass.defaultValue
       }
     }
   }
 
   /** chooses which subtype to delegate to */
   def dispatch[T](ctx: SealedTrait[Default, T])(): Default[T] = new Default[T] {
-    def default = ctx.subtypes.headOption match {
-      case Some(sub) => sub.typeclass.default
+    def defaultValue = ctx.subtypes.headOption match {
+      case Some(sub) => sub.typeclass.defaultValue
       case None => Left("no subtypes")
     }
   }
 
   /** default value for a string; the empty string */
-  implicit val string: Default[String] = new Default[String] { def default = Right("") }
+  implicit val string: Default[String] = new Default[String] { def defaultValue = Right("") }
 
   /** default value for ints; 0 */
-  implicit val int: Default[Int] = new Default[Int] { def default = Right(0) }
+  implicit val int: Default[Int] = new Default[Int] { def defaultValue = Right(0) }
 
   /** oh, no, there is no default Boolean... whatever will we do? */
-  implicit val boolean: Default[Boolean] = new Default[Boolean] { def default = Left("truth is a lie") }
+  implicit val boolean: Default[Boolean] = new Default[Boolean] { def defaultValue = Left("truth is a lie") }
 
   /** default value for sequences; the empty sequence */
   implicit def seq[A]: Default[Seq[A]] = new Typeclass[Seq[A]] { def default = Right(Seq.empty) }


### PR DESCRIPTION
When we went over this example at Scale By the Bay, I was really confused about the different things with different purposes that were all named `default` and I thought it would be easier to read if they had slightly different names to convey their different uses. It does make it less concise but I think that is a tradeoff worth making -- feel free to let me know and reject this PR if you disagree. 

Note that due to https://github.com/propensive/magnolia/issues/144 I was unable to check that it still compiles. The changes are fairly minor so I'm not too concerned, but possibly someone else who can successfully run it should check before merge. 