### PR TITLE
Use a rarely used name for the monad type parameter in constructMonadic

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -249,7 +249,7 @@ object Magnolia {
             override def construct[Return](makeParam: _root_.magnolia.Param[$typeConstructor, $genericType] => Return): $genericType =
               ${genericType.typeSymbol.asClass.module}
 
-            def constructMonadic[F[_], Return](makeParam: _root_.magnolia.Param[$typeConstructor, $genericType] => F[Return])(implicit monadic: _root_.mercator.Monadic[F]): F[$genericType] =
+            def constructMonadic[_F[_], Return](makeParam: _root_.magnolia.Param[$typeConstructor, $genericType] => _F[Return])(implicit monadic: _root_.mercator.Monadic[_F]): F[$genericType] =
               monadic.point(${genericType.typeSymbol.asClass.module})
 
             def rawConstruct(fieldValues: _root_.scala.Seq[_root_.scala.Any]): $genericType =
@@ -393,7 +393,7 @@ object Magnolia {
               override def construct[Return](makeParam: _root_.magnolia.Param[$typeConstructor, $genericType] => Return): $genericType =
                 new $genericType(..$genericParams)
 
-              def constructMonadic[F[_], Return](makeParam: _root_.magnolia.Param[$typeConstructor, $genericType] => F[Return])(implicit monadic: _root_.mercator.Monadic[F]): F[$genericType] = {
+              def constructMonadic[_F[_], Return](makeParam: _root_.magnolia.Param[$typeConstructor, $genericType] => _F[Return])(implicit monadic: _root_.mercator.Monadic[_F]): F[$genericType] = {
                 $constructMonadicImpl
               }
 


### PR DESCRIPTION
Using `F[_]` causes a warning:

```
type parameter F defined in method constructMonadic shadows type F defined in class (...). You may want to rename your type parameter, or possibly remove it.
```

each time magnolia is invoked in a context which is parametrised using `F[_]` itself.