### PR TITLE
Support Java annotations by ignoring them!

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -211,7 +211,9 @@ object Magnolia {
             m.isPrivate
       }.getOrElse(false)
 
-      val classAnnotationTrees = typeSymbol.annotations.map(_.tree).filterNot(_.tpe.typeSymbol.isJavaAnnotation)
+      val isJavaAnnotation: Tree => Boolean = _.tpe.typeSymbol.isJavaAnnotation
+
+      val classAnnotationTrees = typeSymbol.annotations.map(_.tree).filterNot(isJavaAnnotation)
 
       val primitives = Set(typeOf[Double],
                            typeOf[Float],
@@ -339,7 +341,7 @@ object Magnolia {
         } getOrElse List(q"$scalaPkg.None")
 
         val annotations: List[List[Tree]] = headParamList.toList.flatten map { param =>
-          param.annotations map { _.tree }
+          param.annotations.map (_.tree).filterNot(isJavaAnnotation)
         }
 
         val assignments = caseParams.zip(defaults).zip(annotations).zipWithIndex.map {
@@ -442,7 +444,7 @@ object Magnolia {
             q"""$subtypesVal($idx) = $magnoliaPkg.Magnolia.subtype[$typeConstructor, $genericType, $typ](
             ${typeNameRec(typ)},
             $idx,
-            $scalaPkg.Array(..${typ.typeSymbol.annotations.map(_.tree)}),
+            $scalaPkg.Array(..${typ.typeSymbol.annotations.map(_.tree).filterNot(isJavaAnnotation)}),
             _root_.magnolia.CallByNeed($typeclass),
             (t: $genericType) => t.isInstanceOf[$typ],
             (t: $genericType) => t.asInstanceOf[$typ]

--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -211,7 +211,7 @@ object Magnolia {
             m.isPrivate
       }.getOrElse(false)
 
-      val classAnnotationTrees = typeSymbol.annotations.map(_.tree)
+      val classAnnotationTrees = typeSymbol.annotations.map(_.tree).filterNot(_.tpe.typeSymbol.isJavaAnnotation)
 
       val primitives = Set(typeOf[Double],
                            typeOf[Float],

--- a/tests/src/main/scala/JavaExampleAnnotation.java
+++ b/tests/src/main/scala/JavaExampleAnnotation.java
@@ -1,0 +1,5 @@
+package magnolia.tests;
+
+public @interface JavaExampleAnnotation {
+    String description();
+}

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -108,6 +108,7 @@ final case class Lefty() extends Halfy
 final case class Righty() extends Halfy
 
 @MyAnnotation(0)
+@javax.annotation.Resource
 @JavaExampleAnnotation(description = "Some model")
 case class MyDto(foo: String, bar: Int)
 

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -215,6 +215,17 @@ object Tests extends TestApp {
       )
     }.assert(_ == Address("53 High Street", Person("Richard Jones", 44)))
 
+    test("show error stack") {
+      scalac"""
+        case class Alpha(integer: Double)
+        case class Beta(alpha: Alpha)
+        Show.gen[Beta]
+      """
+    }.assert(_ == TypecheckError(txt"""magnolia: could not find Show.Typeclass for type Double
+        |    in parameter 'integer' of product type Alpha
+        |    in parameter 'alpha' of product type Beta
+        |"""))
+
     test("serialize case class with Java annotations by skipping them") {
       Show.gen[MyDto].show(MyDto("foo", 42))
     }.assert(_ == "MyDto{MyAnnotation(0)}(foo=foo,bar=42)")

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -107,6 +107,10 @@ sealed abstract class Halfy
 final case class Lefty() extends Halfy
 final case class Righty() extends Halfy
 
+@MyAnnotation(0)
+@JavaExampleAnnotation(description = "Some model")
+case class MyDto(foo: String, bar: Int)
+
 object Tests extends TestApp {
 
   def tests(): Unit = for (_ <- 1 to 1) {
@@ -211,16 +215,9 @@ object Tests extends TestApp {
       )
     }.assert(_ == Address("53 High Street", Person("Richard Jones", 44)))
 
-    test("show error stack") {
-      scalac"""
-        case class Alpha(integer: Double)
-        case class Beta(alpha: Alpha)
-        Show.gen[Beta]
-      """
-    }.assert(_ == TypecheckError(txt"""magnolia: could not find Show.Typeclass for type Double
-        |    in parameter 'integer' of product type Alpha
-        |    in parameter 'alpha' of product type Beta
-        |"""))
+    test("serialize case class with Java annotations by skipping them") {
+      Show.gen[MyDto].show(MyDto("foo", 42))
+    }.assert(_ == "MyDto{MyAnnotation(0)}(foo=foo,bar=42)")
 
     test("not attempt to instantiate Unit when producing error stack") {
       scalac"""


### PR DESCRIPTION
Java annotations are instantiated in a different way than Scala annotations (which are usually case classes, unlike Java annotations which are interfaces) - by overriding interface methods, instead of passing constructor parameters.

I tried doing that instead of passing the whole annotation call's tree, but apparently something in Scala makes it impossible to instantiate a Java annotation and actually grab an instance.

Should fix #103