### PR TITLE
Add `constructEither` to `CaseClass`

### DIFF
--- a/core/shared/src/main/scala/interface.scala
+++ b/core/shared/src/main/scala/interface.scala
@@ -166,6 +166,8 @@ abstract class CaseClass[Typeclass[_], Type] (
 
   def constructMonadic[Monad[_], PType](makeParam: Param[Typeclass, Type] => Monad[PType])(implicit monadic: Monadic[Monad]): Monad[Type]
 
+  def constructEither[Err, PType](makeParam: Param[Typeclass, Type] => Either[Err, PType]): Either[List[Err], Type]
+
   /** constructs a new instance of the case class type
     *
     *  Like [[construct]] this method is implemented by Magnolia and lets you construct case class

--- a/examples/shared/src/main/scala/decodeSafe.scala
+++ b/examples/shared/src/main/scala/decodeSafe.scala
@@ -1,0 +1,88 @@
+/* Magnolia, version 0.10.0. Copyright 2018 Jon Pretty, Propensive Ltd.
+ *
+ * The primary distribution site is: http://co.ntextu.al/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+import magnolia._
+import scala.language.experimental.macros
+
+/** decoder for converting strings to other types providing good error messages */
+trait DecoderSafe[T] { def decode(str: String): Either[String, T] }
+
+/** derivation object (and companion object) for [[DecoderSafe]] instances */
+object DecoderSafe {
+
+  /** decodes strings */
+  implicit val string: DecoderSafe[String] = (s: String) => Right(s)
+
+  /** decodes ints */
+  implicit val int: DecoderSafe[Int] = { k =>
+    try Right(k.toInt)
+    catch { case _: NumberFormatException => Left(s"illegal number: $k") }
+  }
+
+  /** binds the Magnolia macro to this derivation object */
+  implicit def gen[T]: DecoderSafe[T] = macro Magnolia.gen[T]
+
+  /** type constructor for new instances of the typeclass */
+  type Typeclass[T] = DecoderSafe[T]
+
+  /** defines how new [[DecoderSafe]]s for case classes should be constructed */
+  def combine[T](ctx: CaseClass[DecoderSafe, T]): DecoderSafe[T] = value => {
+    val (_, values) = parse(value)
+    ctx.constructEither { param =>
+      param.typeclass.decode(values(param.label))
+    }.left.map(_.reduce(_ + "\n" + _))
+  }
+
+  /** defines how to choose which subtype of the sealed trait to use for decoding */
+  def dispatch[T](ctx: SealedTrait[DecoderSafe, T]): DecoderSafe[T] = param => {
+    val (name, _) = parse(param)
+    val subtype = ctx.subtypes.find(_.typeName.full == name).get
+    subtype.typeclass.decode(param)
+  }
+
+  /** very simple extractor for grabbing an entire parameter value, assuming matching parentheses */
+  private def parse(value: String): (String, Map[String, String]) = {
+    val end = value.indexOf('(')
+    val name = value.substring(0, end)
+
+    def parts(value: String,
+              idx: Int = 0,
+              depth: Int = 0,
+              collected: List[String] = List("")): List[String] = {
+      def plus(char: Char): List[String] = collected.head + char :: collected.tail
+
+      if (idx == value.length) collected
+      else
+        value(idx) match {
+          case '(' =>
+            parts(value, idx + 1, depth + 1, plus('('))
+          case ')' =>
+            if (depth == 1) plus(')')
+            else parts(value, idx + 1, depth - 1, plus(')'))
+          case ',' =>
+            if (depth == 0) parts(value, idx + 1, depth, "" :: collected)
+            else parts(value, idx + 1, depth, plus(','))
+          case char =>
+            parts(value, idx + 1, depth, plus(char))
+        }
+    }
+
+    def keyValue(str: String): (String, String) = {
+      val List(label, value) = str.split("=", 2).toList
+      (label, value)
+    }
+
+    (name, parts(value.substring(end + 1, value.length - 1)).map(keyValue).toMap)
+  }
+}


### PR DESCRIPTION
Closes #181.

This PR adds a `constructEither` method that allows users to construct case classes in a type safe manner given how to construct each field, where each field can fail with an error and where errors can be accumulated.

This is a special case of a more general `constructApplicative`, which I chose not to implement because we lack an `Applicative` type class and it's not easy to generate one like we do with `Monad` (see my comment in https://github.com/propensive/magnolia/issues/181#issuecomment-542895033). While less general, this method should still be useful for most purposes where people would use `Applicative`.

I tested this by running the following file in `examples/shared/src/main/scala`:

```scala
import scala.language.experimental.macros
import scala.language.higherKinds

object DecoderSafeApp extends App {
  def decodeSafe[A](str: String)(implicit decoder: DecoderSafe[A]): Either[String, A] =
    decoder.decode(str)

  println(decodeSafe[String]("abc"))
  println(decodeSafe[Int]("3"))
  println(decodeSafe[Int]("n"))

  case class MyClass(n: Int, str: String, m: Int)
  println(decodeSafe[MyClass]("(n=3,str=abc,m=1)"))
  println(decodeSafe[MyClass]("(n=n,str=abc,m=1)"))
  println(decodeSafe[MyClass]("(n=n,str=abc,m=m)"))
}
```

The output was, as expected:

```
Right(abc)
Right(3)
Left(illegal number: n)
Right(MyClass(3,abc,1))
Left(illegal number: n)
Left(illegal number: n
illegal number: m)
```