### PR TITLE
Don't cache trees containing Deferred references

### DIFF
--- a/examples/shared/src/main/scala/eq.scala
+++ b/examples/shared/src/main/scala/eq.scala
@@ -50,6 +50,16 @@ object Eq {
   /** equality typeclass instance for integers */
   implicit val int: Eq[Int] = new Eq[Int] { def equal(v1: Int, v2: Int) = v1 == v2 }
 
+  implicit def eqOption[T](implicit T: Eq[T]): Eq[Option[T]] = {
+    case (Some(v1), Some(v2)) => T.equal(v1, v2)
+    case (None, None) => true
+    case _ => false
+  }
+
+  implicit def eqIterable[T, C[x] <: Iterable[x]](implicit T: Eq[T]): Eq[C[T]] = { (v1, v2) =>
+    v1.size == v2.size && (v1.iterator zip v2.iterator).forall((T.equal _).tupled)
+  }
+
   /** binds the Magnolia macro to the `gen` method */
   implicit def gen[T]: Eq[T] = macro Magnolia.gen[T]
 }

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -140,6 +140,9 @@ object PrivateValueClass {
   implicit val show: Show[String, PrivateValueClass] = Show.gen
 }
 
+case class KArray(value: List[KArray])
+case class Wrapper(v:Option[KArray])
+
 object Tests extends TestApp {
 
   def tests(): Unit = for (_ <- 1 to 1) {
@@ -523,5 +526,9 @@ object Tests extends TestApp {
         WeakHash.gen[Entity]
       """
     }.assert(_ == TypecheckError("magnolia: the method `dispatch` must be defined on the derivation object WeakHash to derive typeclasses for sealed traits"))
+
+    test("equality of Wrapper") {
+      Eq.gen[Wrapper].equal(Wrapper(Some(KArray(KArray(Nil) :: Nil))), Wrapper(Some(KArray(KArray(Nil) :: KArray(Nil) :: Nil))))
+    }.assert(_ == false)
   }
 }


### PR DESCRIPTION
Trees containing `Deferred` references might not be self contained
(this is the reason `Deferred` exists in the first place) and should
not be cached. We need to introduce a `shouldCache` parameter to
`recurse` because we have no access to the macro context in `Stack`.

  * Introduce `shouldCache` predicate on trees to `recurse`
  * Introduce `DeferredRef` tree constructor / extractor
  * Don't cache trees that contain `Deferred` references
  * Factor out `Stack.within` method to do `push` and `pop`
  * Expand `recurse` body into pattern matches for clarity

Fixes #185 

P.s. I'm wondering if the cache pulls it's own weight after this.