### PR TITLE
Replace buggy typeSymbol.isJavaAnnotation with a custom solution

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -95,6 +95,7 @@ object Magnolia {
 
     val repeatedParamClass = definitions.RepeatedParamClass
     val scalaSeqType = typeOf[Seq[_]].typeConstructor
+    val javaAnnotationType = typeOf[java.lang.annotation.Annotation]
 
     val prefixType = c.prefix.tree.tpe
     val prefixObject = prefixType.typeSymbol
@@ -117,8 +118,9 @@ object Magnolia {
       abstractTypes.map(_.asClass).flatMap(knownSubclasses(_)) ::: concreteTypes
     }
 
-    def annotationsOf(symbol: Symbol): List[Tree] =
-      symbol.annotations.map(_.tree).filterNot(_.tpe.typeSymbol.isJavaAnnotation)
+    def annotationsOf(symbol: Symbol): List[Tree] = {
+      symbol.annotations.map(_.tree).filterNot(_.tpe <:< javaAnnotationType)
+    }
 
     val typeDefs = prefixType.baseClasses.flatMap { cls =>
       cls.asType.toType.decls.filter(_.isType).find(_.name.toString == "Typeclass").map { tpe =>

--- a/examples/shared/src/main/scala/JavaAnnotatedCase.scala
+++ b/examples/shared/src/main/scala/JavaAnnotatedCase.scala
@@ -1,0 +1,4 @@
+package magnolia.examples
+
+@Deprecated
+case class JavaAnnotatedCase(v: Int)

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -275,6 +275,10 @@ object Tests extends TestApp {
       Show.gen[MyDto].show(MyDto("foo", 42))
     }.assert(_ == "MyDto{MyAnnotation(0)}(foo=foo,bar=42)")
 
+    test("serialize case class with Java annotations which comes from external module by skipping them") {
+      Show.gen[JavaAnnotatedCase].show(JavaAnnotatedCase(1))
+    }.assert(_ == "MyDto{MyAnnotation(0)}(foo=foo,bar=42)")
+
     test("not attempt to instantiate Unit when producing error stack") {
       scalac"""
         case class Gamma(unit: Unit)


### PR DESCRIPTION
This fixes #187 

I know that this is rather a workaround than a proper fix, but I'm not expecting `isJavaAnnotation` to be fixed soon and this issue is quite annoying.