### PR TITLE
Fix #193: Tuple 22 issue

### DIFF
--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -141,7 +141,33 @@ object PrivateValueClass {
 }
 
 case class KArray(value: List[KArray])
-case class Wrapper(v:Option[KArray])
+case class Wrapper(v: Option[KArray])
+
+case class VeryLong(
+  p1: String,
+  p2: String,
+  p3: String,
+  p4: String,
+  p5: String,
+  p6: String,
+  p7: String,
+  p8: String,
+  p9: String,
+  p10: String,
+  p11: String,
+  p12: String,
+  p13: String,
+  p14: String,
+  p15: String,
+  p16: String,
+  p17: String,
+  p18: String,
+  p19: String,
+  p20: String,
+  p21: String,
+  p22: String,
+  p23: String
+)
 
 object Tests extends TestApp {
 
@@ -534,5 +560,33 @@ object Tests extends TestApp {
     test("equality of Wrapper") {
       Eq.gen[Wrapper].equal(Wrapper(Some(KArray(KArray(Nil) :: Nil))), Wrapper(Some(KArray(KArray(Nil) :: KArray(Nil) :: Nil))))
     }.assert(_ == false)
+
+    test("very long") {
+      val vl =
+        VeryLong("p1",
+                 "p2",
+                 "p3",
+                 "p4",
+                 "p5",
+                 "p6",
+                 "p7",
+                 "p8",
+                 "p9",
+                 "p10",
+                 "p11",
+                 "p12",
+                 "p13",
+                 "p14",
+                 "p15",
+                 "p16",
+                 "p17",
+                 "p18",
+                 "p19",
+                 "p20",
+                 "p21",
+                 "p22",
+                 "p23")
+      Eq.gen[VeryLong].equal(vl, vl)
+    }.assert(_ == true)
   }
 }


### PR DESCRIPTION
The issue was related to how we combine the Eithers into the target type. We were building a tuple the size of the case class, but tuples have limits that case classes don't have (anymore). 

So my solution is to limit the size of the tuples we do. If we had `ap` and curried functions, this wouldn't be an issue, but we don't have that atm. 