### PR TITLE
Sort subtypes to ensure consistent ordering (#195)

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -125,10 +125,10 @@ object Magnolia {
       .filter(encl => encl.isVal || encl.isLazy)
       .toSet[Symbol]
 
-    def knownSubclasses(sym: ClassSymbol): List[Symbol] = {
-      val children = sym.knownDirectSubclasses.toList
+    def knownSubclasses(sym: ClassSymbol): Set[Symbol] = {
+      val children = sym.knownDirectSubclasses
       val (abstractTypes, concreteTypes) = children.partition(_.isAbstract)
-      abstractTypes.map(_.asClass).flatMap(knownSubclasses(_)) ::: concreteTypes
+      abstractTypes.map(_.asClass).flatMap(knownSubclasses(_)) ++ concreteTypes
     }
 
     def annotationsOf(symbol: Symbol): List[Tree] = {
@@ -446,7 +446,7 @@ object Magnolia {
           }""")
       } else if (isSealedTrait) {
         checkMethod("dispatch", "sealed traits", "SealedTrait[Typeclass, _]")
-        val genericSubtypes = knownSubclasses(classType.get)
+        val genericSubtypes = knownSubclasses(classType.get).toList.sortBy(_.fullName)
         val subtypes = genericSubtypes.map { sub =>
           val subType = sub.asType.toType // FIXME: Broken for path dependent types
           val typeParams = sub.asType.typeParams

--- a/examples/shared/src/main/scala/typename.scala
+++ b/examples/shared/src/main/scala/typename.scala
@@ -18,18 +18,34 @@ import language.experimental.macros
 
 import magnolia._
 
-trait TypeNameInfo[T] { def name: TypeName }
+trait TypeNameInfo[T] {
+  def name: TypeName
+
+  def subtypeNames: Seq[TypeName]
+}
 
 object TypeNameInfo {
   type Typeclass[T] = TypeNameInfo[T]
   def combine[T](ctx: CaseClass[TypeNameInfo, T]): TypeNameInfo[T] =
-    new TypeNameInfo[T] { def name: TypeName = ctx.typeName }
+    new TypeNameInfo[T] {
+      def name: TypeName = ctx.typeName
+
+      def subtypeNames: Seq[TypeName] = Nil
+    }
 
   def dispatch[T](ctx: SealedTrait[TypeNameInfo, T]): TypeNameInfo[T] =
-    new TypeNameInfo[T] { def name: TypeName = ctx.typeName }
+    new TypeNameInfo[T] {
+      def name: TypeName = ctx.typeName
+
+      def subtypeNames: Seq[TypeName] = ctx.subtypes.map(_.typeName)
+    }
 
   def fallback[T]: TypeNameInfo[T] =
-    new TypeNameInfo[T] { def name: TypeName = TypeName("", "Unknown Type", Seq.empty) }
+    new TypeNameInfo[T] {
+      def name: TypeName = TypeName("", "Unknown Type", Seq.empty)
+
+      def subtypeNames: Seq[TypeName] = Nil
+    }
 
   implicit def gen[T]: TypeNameInfo[T] = macro Magnolia.gen[T]
 }

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -58,6 +58,8 @@ sealed trait Color
 case object Red extends Color
 case object Green extends Color
 case object Blue extends Color
+case object Orange extends Color
+case object Pink extends Color
 
 case class MyAnnotation(order: Int) extends StaticAnnotation
 
@@ -457,9 +459,15 @@ object Tests extends TestApp {
       TypeNameInfo.gen[Color].name
     }.assert(_.full == "magnolia.tests.Color")
 
+    test("sealed trait subtypes should be ordered") {
+      TypeNameInfo.gen[Color].subtypeNames
+    }.assert(_.map(_.short) == Seq("Blue", "Green", "Orange", "Pink", "Red"))
+
     test("case class typeName should be complete and unchanged") {
       implicit val stringTypeName: TypeNameInfo[String] = new TypeNameInfo[String] {
         def name = ???
+
+        def subtypeNames = ???
       }
       TypeNameInfo.gen[Fruit].name
     }.assert(_.full == "magnolia.tests.Fruit")


### PR DESCRIPTION
This PR closes #195.

NB I reused `TypeNameInfo` to test the order of sealed traits but happy to introduce a new type for the test if you prefer. I also extended the `Color` trait to have more than 4 subtypes to demonstrate the unknown order problem. Not many comments in the code so didn't add one but happy to put one in if you think it would be helpful.