### PR TITLE
Remove usage of Either.LeftProjection.get

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -406,7 +406,7 @@ object Magnolia {
                _root_.scala.Right(new $genericType(..${eitherVals.map(_._2)}))
              case _ =>
                _root_.scala.Left(
-                 _root_.scala.List(..${eitherVals.map(_._1)}).filter(_.isLeft).map(_.left.get)
+                 _root_.scala.List(..${eitherVals.map(_._1)}).collect { case Left(x) => x }
                )
            }
          """


### PR DESCRIPTION
In Scala 2.13 this method was deprecated, and let's projects that use
magnolia fail if fatal warnings are active.

I replaced the `filter` followed by `.left.get` with a `collect` to
get rid of the warning.

For reference, the exact message is:

```scala
method get in class LeftProjection is deprecated (since 2.13.0): use `Either.swap.getOrElse` instead
```