### PR TITLE
Fix ugly error message for Java enums

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -223,8 +223,7 @@ object Magnolia {
       val classType = if (typeSymbol.isClass) Some(typeSymbol.asClass) else None
       val isCaseClass = classType.exists(_.isCaseClass)
       val isCaseObject = classType.exists(_.isModuleClass)
-      val isSealedTrait = classType.exists(_.isSealed)
-
+      val isSealedTrait = classType.exists(ct => ct.isSealed && !ct.isJavaEnum)
       val classAnnotationTrees = annotationsOf(typeSymbol)
 
       val primitives = Set(typeOf[Double],

--- a/tests/src/main/java/magnolia/tests/WeekDay.java
+++ b/tests/src/main/java/magnolia/tests/WeekDay.java
@@ -1,0 +1,5 @@
+package magnolia.tests;
+
+public enum WeekDay {
+    Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday;
+}

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -596,5 +596,9 @@ object Tests extends TestApp {
                  "p23")
       Eq.gen[VeryLong].equal(vl, vl)
     }.assert(_ == true)
+
+    test("not attempt to derive instances for Java enums") {
+      scalac"Show.gen[WeekDay]"
+    }.assert(_ == TypecheckError(txt"magnolia: could not infer Show.Typeclass for type magnolia.tests.WeekDay"))
   }
 }


### PR DESCRIPTION
Java enums are considered sealed but are not traits.

Ref #137