### PR TITLE
Replace usage of javax annotation

### DIFF
--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -112,7 +112,7 @@ final case class Lefty() extends Halfy
 final case class Righty() extends Halfy
 
 @MyAnnotation(0)
-@javax.annotation.Resource
+@SuppressWarnings(Array("deprecation"))
 @JavaExampleAnnotation(description = "Some model")
 case class MyDto(foo: String, bar: Int)
 


### PR DESCRIPTION
`javax.annotation` is not part of the JDK since Java 11.