### PR TITLE
Remove unnecessary condition for lazy val

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -184,7 +184,7 @@ object Magnolia {
         case tree => enclosingVals.contains(tree.symbol)
       }
 
-      if (!fullauto || shouldBeLazy) q"lazy val $name: $tpe = $rhs"
+      if (shouldBeLazy) q"lazy val $name: $tpe = $rhs"
       else q"val $name = $rhs"
     }
 


### PR DESCRIPTION
I don't see why semiauto should always be lazy.

Fixes #214