### PR TITLE
Exclude scala-compiler too

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
   .settings(scalaMacroDependencies)
   .settings(moduleName := "magnolia")
   .settings(libraryDependencies ++= Seq(
-    ("com.propensive" %% "mercator" % "0.2.1").exclude("org.scala-lang", "scala-reflect")
+    ("com.propensive" %% "mercator" % "0.2.1")
+      .exclude("org.scala-lang", "scala-reflect")
+      .exclude("org.scala-lang", "scala-compiler")
   ))
 
 lazy val coreJVM = core.jvm


### PR DESCRIPTION
As reported on gitter:
```
Matthias Berndt @mberndt123 20:43
No, it's not fixed
It's still pulled in via mercator
mercator 0.2.1 has a normal (non-"Provided") dependency on scala-compiler, and magnolia 0.15.0 depends on mercator 0.2.1
Am I missing something here?
```