### PR TITLE
Resolve alias for context typename (fixes #259)

### DIFF
--- a/core/shared/src/main/scala/magnolia.scala
+++ b/core/shared/src/main/scala/magnolia.scala
@@ -305,7 +305,7 @@ object Magnolia {
         q"$magnoliaPkg.TypeName(${ts.owner.fullName}, ${ts.name.decodedName.toString}, $typeArgNames)"
       }
 
-      val typeNameDef = q"val $typeName = ${typeNameRec(genericType)}"
+      val typeNameDef = q"val $typeName = ${typeNameRec(genericType.dealias)}"
 
       val result = if (isRefinedType) {
         error(s"could not infer $prefixName.Typeclass for refined type $genericType")

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -608,6 +608,12 @@ object Tests extends TestApp {
       Show.gen[Path[String]].show(OffRoad(Some(Crossroad(Destination("A"), Destination("B")))))
     }.assert(_ == "OffRoad[String](path=Crossroad[String](left=Destination[String](value=A),right=Destination[String](value=B)))")
 
+    test("resolve aliases for type names") {
+      type LO[X] = Leaf[Option[X]]
+
+      Show.gen[LO[String]].show(Leaf(None))
+    }.assert(_.contains("Leaf[Option[String]]"))
+
     test("capture attributes against params") {
       Show.gen[Attributed].show(Attributed("xyz", 100))
     }.assert(_ == "Attributed{MyAnnotation(0)}(p1{MyAnnotation(1)}=xyz,p2{MyAnnotation(2)}=100)")


### PR DESCRIPTION
See #259 
The test added by this PR is failing without the `.dealias` patch