### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 jdk:
 - openjdk8
 scala:
-- 2.12.11
-- 2.13.1
+- 2.12.12
+- 2.13.3
 before_install:
 - bash scripts/decrypt_files_if_not_pr.sh
 before_cache:
@@ -29,4 +29,4 @@ deploy:
   skip_cleanup: true
   on:
     all_branches: true
-    condition: $TRAVIS_SCALA_VERSION = "2.12.11" && $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?
+    condition: $TRAVIS_SCALA_VERSION = "2.12.12" && $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.softwaremill.PublishTravis.publishTravisSettings
 
-val v2_12 = "2.12.11"
-val v2_13 = "2.13.1"
+val v2_12 = "2.12.12"
+val v2_13 = "2.13.3"
 
 lazy val core = crossProject(JVMPlatform, JSPlatform)
   .in(file("core"))
@@ -42,7 +42,7 @@ lazy val tests = project
       // These two to allow compilation under Java 9...
       // Specifically to import XML stuff that got modularised
       "javax.xml.bind" % "jaxb-api" % "2.3.1" % "compile",
-      "com.sun.xml.bind" % "jaxb-impl" % "2.3.2" % "compile"
+      "com.sun.xml.bind" % "jaxb-impl" % "2.3.3" % "compile"
     )
   )
   // compiling and running the tests only for 2.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill" % "1.7.5")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.2.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")


### PR DESCRIPTION
Update: Scala 2.12.12, 2.13.3
Dependencies: jaxb-impl 2.3.3
Plugins: sbt-scalajs 1.0.1, sbt-scoverage 1.6.1

Very nice library, I enjoyed your talks and experimenting with deriving using Magnolia ❤️ 

BTW if you set up Scala steward you can have automatic PR's with dependency updates if you [add magnolia here](https://github.com/scala-steward-org/repos/blob/master/repos-github.md).
Moreover those can be automatically merge of by [mergify.io](https://mergify.io/) if they meet certain conditions like pass build.
Works for [my](https://github.com/lemastero/Triglav/blob/master/.mergify.yml) [projects](https://github.com/lemastero/scala_typeclassopedia/blob/master/.mergify.yml) and in [zio](https://github.com/zio/zio/blob/master/.mergify.yml), [zio-prelude](https://github.com/zio/zio-prelude/blob/master/.mergify.yml).