### PR TITLE
Exclude params and cons from the derivation based on annotations

### DIFF
--- a/core/shared/src/main/scala/interface.scala
+++ b/core/shared/src/main/scala/interface.scala
@@ -15,7 +15,7 @@
 package magnolia
 
 import language.experimental.macros
-import scala.annotation.tailrec
+import scala.annotation.{StaticAnnotation, tailrec}
 import mercator._
 
 /** represents a subtype of a sealed trait
@@ -455,8 +455,7 @@ object MagnoliaUtil {
 
 /**
  * Marker trait for annotations which when encountered on either a parameter or a constructor,
- * the derivation will not look for a typeclass instance, instead bind the typeclass parameter
- * on the interface to the 'bind[A]: Typeclass[A]' method of the enclosing class.
- *
+ * the derivation will not look for a typeclass instance but use the 'fallback[T]: Typeclass[T]'
+ * method of the enclosing class instead.
  * */
-trait RuntimeBoundTypeclass
+trait ForceFallbackDerivation extends StaticAnnotation

--- a/core/shared/src/main/scala/interface.scala
+++ b/core/shared/src/main/scala/interface.scala
@@ -452,3 +452,11 @@ object MagnoliaUtil {
     values.toList.collect { case Left(v) => v }
 
 }
+
+/**
+ * Marker trait for annotations which when encountered on either a parameter or a constructor,
+ * the derivation will not look for a typeclass instance, instead bind the typeclass parameter
+ * on the interface to the 'bind[A]: Typeclass[A]' method of the enclosing class.
+ *
+ * */
+trait RuntimeBoundTypeclass

--- a/core/shared/src/main/scala/interface.scala
+++ b/core/shared/src/main/scala/interface.scala
@@ -458,4 +458,4 @@ object MagnoliaUtil {
  * the derivation will not look for a typeclass instance but use the 'fallback[T]: Typeclass[T]'
  * method of the enclosing class instead.
  * */
-trait ForceFallbackDerivation extends StaticAnnotation
+trait ExcludeFromDerivation extends StaticAnnotation

--- a/examples/shared/src/main/scala/partialsemiauto.scala
+++ b/examples/shared/src/main/scala/partialsemiauto.scala
@@ -1,0 +1,81 @@
+import java.util.UUID
+
+import scala.language.experimental.macros
+import magnolia._
+
+import scala.annotation.StaticAnnotation
+
+trait PartialSemiDefault[A] {
+  def default: A
+}
+
+case class ForceProvidedDefault() extends StaticAnnotation with RuntimeBoundTypeclass
+case class NoDefault() extends StaticAnnotation with RuntimeBoundTypeclass
+
+object PartialSemiDefault {
+  @inline def apply[A](implicit A: PartialSemiDefault[A]): PartialSemiDefault[A] = A
+
+  type Typeclass[T] = PartialSemiDefault[T]
+
+  def bind[T]: PartialSemiDefault[T] = ??? // this will never be called because of how combine/dispatch is implemented
+
+  def combine[T](ctx: CaseClass[PartialSemiDefault, T]): PartialSemiDefault[T] = new PartialSemiDefault[T] {
+    def default = ctx.construct { p =>
+      p.default.getOrElse {
+        if (p.annotations.collectFirst {
+          case ForceProvidedDefault() => true
+        }.nonEmpty) {
+          throw new IllegalStateException(s"ForceProvidedDefault on $p but no explicit default provided")
+        } else {
+          p.typeclass.default
+        }
+      }
+    }
+  }
+  def dispatch[T](ctx: SealedTrait[PartialSemiDefault, T])(): PartialSemiDefault[T] = new PartialSemiDefault[T] {
+    def default =
+      ctx.subtypes
+        .filterNot { subtype =>
+          subtype.annotations.exists {
+            case NoDefault() => true
+            case _ => false
+          }
+        }
+        .head
+        .typeclass
+        .default
+  }
+
+  implicit val string: PartialSemiDefault[String] = new PartialSemiDefault[String] { def default = "" }
+  implicit val int: PartialSemiDefault[Int] = new PartialSemiDefault[Int] { def default = 0 }
+
+  @debug() def gen[T]: PartialSemiDefault[T] = macro Magnolia.gen[T]
+}
+
+object PartialSemiDefaultTest extends App {
+  sealed trait Data
+  object Data {
+    implicit val d1: PartialSemiDefault[Data] = PartialSemiDefault.gen
+  }
+
+  // Data1 is fully derivable
+  case class Data1(a: Int = 10, b: String) extends Data
+  object Data1 {
+    implicit val d: PartialSemiDefault[Data1] = PartialSemiDefault.gen
+  }
+
+  // Data2's Double and UUID does not have an implicit typeclass instance. Even though we provide a default value,
+  // without the annotation Magnolia would fail on implicit not found
+  case class Data2(c: Data1, @ForceProvidedDefault d: Double = 3.14, @ForceProvidedDefault e: UUID = UUID.randomUUID()) extends Data
+  object Data2 {
+    implicit val d: PartialSemiDefault[Data2] = PartialSemiDefault.gen
+  }
+
+  // Data3 is non derivable as it has no default for parameter f, and we don't have a default typeclass instance for UUID,
+  // but by marking it with the annotation we can ignore it in dispatch
+  @NoDefault case class Data3(f: UUID) extends Data
+
+  println(implicitly[PartialSemiDefault[Data]].default)
+  println(implicitly[PartialSemiDefault[Data1]].default)
+  println(implicitly[PartialSemiDefault[Data2]].default)
+}

--- a/examples/shared/src/main/scala/partialsemiauto.scala
+++ b/examples/shared/src/main/scala/partialsemiauto.scala
@@ -10,15 +10,13 @@ trait PartialSemiDefault[A] {
   def default: A
 }
 
-case class ForceProvidedDefault() extends StaticAnnotation with ForceFallbackDerivation
-case class NoDefault() extends StaticAnnotation with ForceFallbackDerivation
+case class ForceProvidedDefault() extends StaticAnnotation with ExcludeFromDerivation
+case class NoDefault() extends StaticAnnotation with ExcludeFromDerivation
 
 object PartialSemiDefault {
   @inline def apply[A](implicit A: PartialSemiDefault[A]): PartialSemiDefault[A] = A
 
   type Typeclass[T] = PartialSemiDefault[T]
-
-  def fallback[T]: PartialSemiDefault[T] = ??? // this will never be called because of how combine/dispatch is implemented
 
   def combine[T](ctx: CaseClass[PartialSemiDefault, T]): PartialSemiDefault[T] = new PartialSemiDefault[T] {
     def default = ctx.construct { p =>

--- a/examples/shared/src/main/scala/partialsemiauto.scala
+++ b/examples/shared/src/main/scala/partialsemiauto.scala
@@ -1,3 +1,5 @@
+package magnolia.examples
+
 import java.util.UUID
 import scala.language.experimental.macros
 import magnolia._
@@ -48,10 +50,12 @@ object PartialSemiDefault {
   implicit val string: PartialSemiDefault[String] = new PartialSemiDefault[String] { def default = "" }
   implicit val int: PartialSemiDefault[Int] = new PartialSemiDefault[Int] { def default = 0 }
 
-  @debug() def gen[T]: PartialSemiDefault[T] = macro Magnolia.gen[T]
+  def gen[T]: PartialSemiDefault[T] = macro Magnolia.gen[T]
 }
 
-object PartialSemiDefaultTest extends App {
+object PartialSemiDefaultExample extends App {
+  val fallbackUUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+
   sealed trait Data
   object Data {
     implicit val d1: PartialSemiDefault[Data] = PartialSemiDefault.gen
@@ -65,7 +69,7 @@ object PartialSemiDefaultTest extends App {
 
   // Data2's Double and UUID does not have an implicit typeclass instance. Even though we provide a default value,
   // without the annotation Magnolia would fail on implicit not found
-  case class Data2(c: Data1, @ForceProvidedDefault d: Double = 3.14, @ForceProvidedDefault e: UUID = UUID.randomUUID()) extends Data
+  case class Data2(c: Data1, @ForceProvidedDefault d: Double = 3.14, @ForceProvidedDefault e: UUID = fallbackUUID) extends Data
   object Data2 {
     implicit val d: PartialSemiDefault[Data2] = PartialSemiDefault.gen
   }
@@ -73,8 +77,4 @@ object PartialSemiDefaultTest extends App {
   // Data3 is non derivable as it has no default for parameter f, and we don't have a default typeclass instance for UUID,
   // but by marking it with the annotation we can ignore it in dispatch
   @NoDefault case class Data3(f: UUID) extends Data
-
-  println(implicitly[PartialSemiDefault[Data]].default)
-  println(implicitly[PartialSemiDefault[Data1]].default)
-  println(implicitly[PartialSemiDefault[Data2]].default)
 }

--- a/examples/shared/src/main/scala/partialsemiauto.scala
+++ b/examples/shared/src/main/scala/partialsemiauto.scala
@@ -1,5 +1,4 @@
 import java.util.UUID
-
 import scala.language.experimental.macros
 import magnolia._
 
@@ -9,15 +8,15 @@ trait PartialSemiDefault[A] {
   def default: A
 }
 
-case class ForceProvidedDefault() extends StaticAnnotation with RuntimeBoundTypeclass
-case class NoDefault() extends StaticAnnotation with RuntimeBoundTypeclass
+case class ForceProvidedDefault() extends StaticAnnotation with ForceFallbackDerivation
+case class NoDefault() extends StaticAnnotation with ForceFallbackDerivation
 
 object PartialSemiDefault {
   @inline def apply[A](implicit A: PartialSemiDefault[A]): PartialSemiDefault[A] = A
 
   type Typeclass[T] = PartialSemiDefault[T]
 
-  def bind[T]: PartialSemiDefault[T] = ??? // this will never be called because of how combine/dispatch is implemented
+  def fallback[T]: PartialSemiDefault[T] = ??? // this will never be called because of how combine/dispatch is implemented
 
   def combine[T](ctx: CaseClass[PartialSemiDefault, T]): PartialSemiDefault[T] = new PartialSemiDefault[T] {
     def default = ctx.construct { p =>

--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -732,5 +732,13 @@ object Tests extends TestApp {
     test("support dispatch without combine") {
       implicitly[NoCombine[Halfy]].nameOf(Righty())
     }.assert(_ == "Righty")
+
+    test("support forcing the fallback method to constructors via annotations") {
+      implicitly[PartialSemiDefault[PartialSemiDefaultExample.Data]].default
+    }.assert(_ == PartialSemiDefaultExample.Data1(10, ""))
+
+    test("support forcing the fallback method to parameters via annotations") {
+      implicitly[PartialSemiDefault[PartialSemiDefaultExample.Data2]].default
+    }.assert(_ == PartialSemiDefaultExample.Data2(PartialSemiDefaultExample.Data1(10, ""), 3.14, PartialSemiDefaultExample.fallbackUUID))
   }
 }


### PR DESCRIPTION
This is a feature request with possible proof-of-concept implementation. I would be happy to work on an alternative approach if there is any.

### The problem
The real-world example for the requested feature came up while trying to migrate the semi-auto derived _binary codecs_ in https://github.com/vigoo/desert/ from shapeless to magnolia. It supports marking case class fields and sealed trait constructors as _transient_. These transient subtrees of a data type may have types for which there is no implicit binary codec available and it cannot be automatically derived either. Even though the transient annotations can be observed from magnolia's `combine`/`dispatch` methods, as the derivation engine does not know about these application-specific exclusion rules it tries to gather typeclass instances for these members too, and fails.

### A possible solution
In this PR I created a possible solution for the above problem, while trying to keep it as generic as possible.
What I came up with is the following:

- There is a marker trait `RuntimeBoundTypeclass` to be mixed in to `StaticAnnotations` 
- This is used to communicate with the derivation engine that we don't need to look for the typeclass instance for a given parameter or subclass
- In order to not break the API we still need to have a `Typeclass[T]` value somehow. What I did is to defer getting the value to a user-defined function `bind[T]: Typeclass[T]` in the enclosing object.

For the use case I described above, `bind` will never be called so it can just throw an exception; `combine` and `dispatch` can detect the annotations and simply not call `.typeclass` that is bound to `bind`.
I also included a simpler example that is based on the `Default` typeclass's example.

Note that this provides an alternative solution for https://github.com/propensive/magnolia/issues/61 too
