### PR TITLE
Expose SealedTrait.Subtype constructor fields

### DIFF
--- a/src/core/interface.scala
+++ b/src/core/interface.scala
@@ -85,7 +85,7 @@ object SealedTrait:
                 val annotations: IArray[Any],
                 val typeAnnotations: IArray[Any],
                 val isObject: Boolean,
-                index: Int,
+                val index: Int,
                 callByNeed: CallByNeed[Typeclass[SType]],
                 isType: Type => Boolean,
                 asType: Type => SType & Type


### PR DESCRIPTION
In some usecases, the typeclass instance of a subtype can be modified, so it is useful to allow library authors to recreate the Subtype.

This is the case for difflicious since you can be given a `Differ[ComplexType]` and be able to "tweak" the individual Differs that made up the `Differ[ComplexType]` instance. In the Scala 2 implementation, You can see me [recreating Subtype after transforming the subtype's Differ](https://github.com/jatcwang/difflicious/blob/f5f7b10fbd995d6c69b17a94e051105558daae49/modules/core/src/main/scala/difflicious/DifferGen.scala)

