### PR TITLE
Use Scaladex badge on ReadMe to show Scala version support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 [<img alt="GitHub Workflow" src="https://img.shields.io/github/workflow/status/softwaremill/magnolia/CI/scala3?style=for-the-badge" height="24">](https://github.com/softwaremill/magnolia/actions)
 [<img src="https://img.shields.io/badge/gitter-discuss-f00762?style=for-the-badge" height="24">](https://gitter.im/softwaremill/magnolia)
-[<img src="https://img.shields.io/maven-central/v/com.softwaremill.magnolia1_3/magnolia_3?color=2465cd&style=for-the-badge" height="24">](https://search.maven.org/artifact/com.softwaremill.magnolia1_3/magnolia_3)
+[<img src="https://index.scala-lang.org/softwaremill/magnolia/magnolia/latest-by-scala-version.svg?color=2465cd&style=for-the-badge" height="24">](https://index.scala-lang.org/softwaremill/magnolia/magnolia)
 
 # Magnolia
 


### PR DESCRIPTION
This Scaladex badge summarises which versions of Scala are supported by `magnolia`, and what the latest `magnolia` version is for each of those Scala versions (so it provides a bit more information than a simple Maven badge):

[<img src="https://index.scala-lang.org/softwaremill/magnolia/magnolia/latest-by-scala-version.svg?color=2465cd&style=for-the-badge" height="24">](https://index.scala-lang.org/softwaremill/magnolia/magnolia)

More details on the badge format: https://github.com/scalacenter/scaladex/pull/660
