### PR TITLE
Replace summonOption with summonFrom

### DIFF
--- a/src/core/magnolia.scala
+++ b/src/core/magnolia.scala
@@ -124,10 +124,10 @@ trait Derivation[TypeClass[_]] extends CommonDerivation[TypeClass]:
           IArray.from(paramTypeAnns[T]),
           isObject[s],
           idx,
-          CallByNeed(
-            summonOption[Typeclass[s]]
-              .getOrElse(derived[s](using summonInline[Mirror.Of[s]]))
-          ),
+          CallByNeed(summonFrom {
+            case tc: Typeclass[`s`] => tc
+            case _ => derived(using summonInline[Mirror.Of[s]])
+          }),
           x => m.ordinal(x) == idx,
           _.asInstanceOf[s & T]
         ) :: subtypes[T, tail](m, idx + 1)


### PR DESCRIPTION
`summonOption` generates both branches and resolves at runtime.
`summonFrom` resolves at compile time and generates only one branch.