### PR TITLE
Setup sourcegraph for scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: coursier/setup-action@v1.1.2
         with:
-          java-version: 11
+          jvm: adopt:11
       - name: Cache sbt
         uses: coursier/cache-action@v6
         with:
@@ -40,9 +40,9 @@ jobs:
         with:
           fetch-depth: 0 # checkout tags so that dynver works properly (we need the version for MiMa)
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: coursier/setup-action@v1.1.2
         with:
-          java-version: 11
+          jvm: adopt:11
       - name: Cache sbt
         uses: coursier/cache-action@v6
         with:
@@ -89,9 +89,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: coursier/setup-action@v1.1.2
         with:
-          java-version: 11
+          jvm: adopt:11
       - name: Cache sbt
         uses: coursier/cache-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,33 @@ jobs:
       - name: Check MiMa # disable for major releases
         run: sbt -v core3/mimaReportBinaryIssues
 
+  sourcegraph:
+    # run on external PRs, but not on internal PRs since those will be run by push to branch
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-20.04
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.1.2
+        with:
+          jvm: adopt:11
+          apps: lsif-java
+      - name: Cache sbt
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: sbt-cache-${{ runner.os }}
+      - name: Generate LSIF
+        run: lsif-java index 
+      - name: Upload LSIF data
+        uses: sourcegraph/lsif-upload-action@master
+        with:
+          endpoint: https://sourcegraph.com
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dump.lsif
+
   publish:
     name: Publish release
     needs: [ci]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: sbt -v core3/mimaReportBinaryIssues
 
   sourcegraph:
+    name: Upload index to sourcegraph
+    needs: [ci]
     # run on external PRs, but not on internal PRs since those will be run by push to branch
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-20.04

--- a/build.sbt
+++ b/build.sbt
@@ -80,3 +80,10 @@ lazy val test = (projectMatrix in file(".test"))
   )
   .jvmPlatform(scalaVersions = List(scala3))
   .jsPlatform(scalaVersions = List(scala3))
+
+inThisBuild(
+  List(
+    semanticdbEnabled := true,
+    semanticdbVersion := "4.4.33"
+  )
+)


### PR DESCRIPTION
This PR apart from adding integration with sourcegraph also unifies how java is being set. 
The unification part can be revert or done otherwise if desired. 

`actions/setup-java@v1` supports only one distribution -  Zulu OpenJDK (Note that v2 supports wider variety of distributions)
That means PR also changes openjdk distro which is used by the CI pipeline.

While I believe that both changes (unification and switch to Zulu) are beneficial I can agree that they might be split into multiple PRs for better transparency (if needed). 
