### PR TITLE
Setup sourcegraph for scala 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,19 +65,18 @@ jobs:
         uses: coursier/setup-action@v1.1.2
         with:
           jvm: adopt:11
-          apps: lsif-java
       - name: Cache sbt
         uses: coursier/cache-action@v6
         with:
           extraKey: sbt-cache-${{ runner.os }}
       - name: Generate LSIF
-        run: lsif-java index
+        run: sbt 'set every semanticdbEnabled := true; set every semanticdbVersion := "4.4.33"' sourcegraphLsif
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
         with:
           endpoint: https://sourcegraph.com
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dump.lsif
+          file: target/sbt-sourcegraph/dump.lsif
 
   publish:
     name: Publish release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: coursier/setup-action@v1.1.2
         with:
-          java-version: 11
+          jvm: adopt:11
       - name: Cache sbt
         uses: coursier/cache-action@v6
         with:
@@ -40,15 +40,44 @@ jobs:
         with:
           fetch-depth: 0 # checkout tags so that dynver works properly (we need the version for MiMa)
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: coursier/setup-action@v1.1.2
         with:
-          java-version: 11
+          jvm: adopt:11
       - name: Cache sbt
         uses: coursier/cache-action@v6
         with:
           extraKey: sbt-cache-${{ runner.os }}
       - name: Check MiMa # disable for major releases
         run: sbt -v core/mimaReportBinaryIssues
+
+  sourcegraph:
+    name: Upload index to sourcegraph
+    needs: [ci]
+    # run on external PRs, but not on internal PRs since those will be run by push to branch
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-20.04
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.1.2
+        with:
+          jvm: adopt:11
+          apps: lsif-java
+      - name: Cache sbt
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: sbt-cache-${{ runner.os }}
+      - name: Generate LSIF
+        run: lsif-java index
+      - name: Upload LSIF data
+        uses: sourcegraph/lsif-upload-action@master
+        with:
+          endpoint: https://sourcegraph.com
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dump.lsif
 
   publish:
     name: Publish release
@@ -61,9 +90,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: coursier/setup-action@v1.1.2
         with:
-          java-version: 11
+          jvm: adopt:11
       - name: Cache sbt
         uses: coursier/cache-action@v6
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -76,10 +76,3 @@ lazy val test = (projectMatrix in file("test"))
   )
   .jvmPlatform(scalaVersions = scala2)
   .jsPlatform(scalaVersions = scala2)
-
-inThisBuild(
-  List(
-    semanticdbEnabled := true,
-    semanticdbVersion := "4.4.33"
-  )
-)

--- a/build.sbt
+++ b/build.sbt
@@ -76,3 +76,10 @@ lazy val test = (projectMatrix in file("test"))
   )
   .jvmPlatform(scalaVersions = scala2)
   .jsPlatform(scalaVersions = scala2)
+
+inThisBuild(
+  List(
+    semanticdbEnabled := true,
+    semanticdbVersion := "4.4.33"
+  )
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-publish" % 
 addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.8.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
+
+addSbtPlugin("com.sourcegraph" % "sbt-sourcegraph" % "0.3.3")


### PR DESCRIPTION
This PR apart from adding integration with sourcegraph also unifies how java is being set.
The unification part can be revert or done otherwise if desired.

Old `actions/setup-java@v1` supported only one distribution - Zulu OpenJDK (Note that v2 supports wider variety of distributions)
That means PR also changes openjdk distro which is used by the CI pipeline.

This is a complementary PR for https://github.com/softwaremill/magnolia/pull/369 which is currently on hold as something doesn't work correctly for scala3.