### PR TITLE
Refactor Derivation interface

### DIFF
--- a/src/core/impl.scala
+++ b/src/core/impl.scala
@@ -99,12 +99,14 @@ object CaseClassDerivation:
           )
 end CaseClassDerivation
 
-trait SealedTraitDerivation[TypeClass[_]]:
-  protected inline def deriveSubtype[s](m: Mirror.Of[s]): TypeClass[s]
+trait SealedTraitDerivation:
+  type Typeclass[T]
+
+  protected inline def deriveSubtype[s](m: Mirror.Of[s]): Typeclass[s]
 
   protected inline def sealedTraitFromMirror[A](
       m: Mirror.SumOf[A]
-  ): SealedTrait[TypeClass, A] =
+  ): SealedTrait[Typeclass, A] =
     SealedTrait(
       typeInfo[A],
       IArray(subtypesFromMirror[A, m.MirroredElemTypes](m)*),
@@ -117,7 +119,7 @@ trait SealedTraitDerivation[TypeClass[_]]:
   protected transparent inline def subtypesFromMirror[A, SubtypeTuple <: Tuple](
       m: Mirror.SumOf[A],
       idx: Int = 0
-  ): List[SealedTrait.Subtype[TypeClass, A, _]] =
+  ): List[SealedTrait.Subtype[Typeclass, A, _]] =
     inline erasedValue[SubtypeTuple] match
       case _: EmptyTuple =>
         Nil
@@ -130,7 +132,7 @@ trait SealedTraitDerivation[TypeClass[_]]:
           isObject[s],
           idx,
           CallByNeed(summonFrom {
-            case tc: TypeClass[`s`] => tc
+            case tc: Typeclass[`s`] => tc
             case _ => deriveSubtype(summonInline[Mirror.Of[s]])
           }),
           x => m.ordinal(x) == idx,

--- a/src/core/impl.scala
+++ b/src/core/impl.scala
@@ -1,0 +1,138 @@
+package magnolia1
+
+import scala.compiletime.*
+import scala.deriving.Mirror
+import scala.reflect.*
+
+import Macro.*
+
+object Impl:
+  inline def getCaseClass[Typeclass[_], A](
+      product: Mirror.ProductOf[A]
+  ): CaseClass[Typeclass, A] =
+    val parameters = IArray(
+      getParams[
+        Typeclass,
+        A,
+        product.MirroredElemLabels,
+        product.MirroredElemTypes
+      ](
+        paramAnns[A].to(Map),
+        inheritedParamAnns[A].to(Map),
+        paramTypeAnns[A].to(Map),
+        repeated[A].to(Map),
+        defaultValue[A].to(Map)
+      )*
+    )
+
+    new CaseClass(
+      typeInfo[A],
+      isObject[A],
+      isValueClass[A],
+      parameters,
+      IArray(anns[A]*),
+      IArray(inheritedAnns[A]*),
+      IArray[Any](typeAnns[A]*)
+    ):
+      def construct[PType: ClassTag](makeParam: Param => PType): A =
+        product.fromProduct(Tuple.fromArray(params.map(makeParam).to(Array)))
+
+      def rawConstruct(fieldValues: Seq[Any]): A =
+        product.fromProduct(Tuple.fromArray(fieldValues.to(Array)))
+
+      def constructEither[Err, PType: ClassTag](
+          makeParam: Param => Either[Err, PType]
+      ): Either[List[Err], A] =
+        params
+          .map(makeParam)
+          .foldLeft[Either[List[Err], Array[PType]]](Right(Array())) {
+            case (Left(errs), Left(err))    => Left(errs ++ List(err))
+            case (Right(acc), Right(param)) => Right(acc ++ Array(param))
+            case (errs @ Left(_), _)        => errs
+            case (_, Left(err))             => Left(List(err))
+          }
+          .map { params => product.fromProduct(Tuple.fromArray(params)) }
+
+      def constructMonadic[M[_]: Monadic, PType: ClassTag](
+          makeParam: Param => M[PType]
+      ): M[A] = {
+        val m = summon[Monadic[M]]
+        m.map {
+          params.map(makeParam).foldLeft(m.point(Array())) { (accM, paramM) =>
+            m.flatMap(accM) { acc =>
+              m.map(paramM)(acc ++ List(_))
+            }
+          }
+        } { params => product.fromProduct(Tuple.fromArray(params)) }
+      }
+
+  inline def getParams[Typeclass[_], A, Labels <: Tuple, Params <: Tuple](
+      annotations: Map[String, List[Any]],
+      inheritedAnnotations: Map[String, List[Any]],
+      typeAnnotations: Map[String, List[Any]],
+      repeated: Map[String, Boolean],
+      defaults: Map[String, Option[() => Any]],
+      idx: Int = 0
+  ): List[CaseClass.Param[Typeclass, A]] =
+    inline erasedValue[(Labels, Params)] match
+      case _: (EmptyTuple, EmptyTuple) =>
+        Nil
+      case _: ((l *: ltail), (p *: ptail)) =>
+        val label = constValue[l].asInstanceOf[String]
+        CaseClass.Param[Typeclass, A, p](
+          label,
+          idx,
+          repeated.getOrElse(label, false),
+          CallByNeed(summonInline[Typeclass[p]]),
+          CallByNeed(defaults.get(label).flatten.map(_.apply.asInstanceOf[p])),
+          IArray.from(annotations.getOrElse(label, List())),
+          IArray.from(inheritedAnnotations.getOrElse(label, List())),
+          IArray.from(typeAnnotations.getOrElse(label, List()))
+        ) ::
+          getParams[Typeclass, A, ltail, ptail](
+            annotations,
+            inheritedAnnotations,
+            typeAnnotations,
+            repeated,
+            defaults,
+            idx + 1
+          )
+
+  trait Subtypes:
+    protected type Typeclass[_]
+    protected inline def deriveSubtype[s](m: Mirror.Of[s]): Typeclass[s]
+
+    protected inline def getSealedTrait[A](
+        m: Mirror.SumOf[A]
+    ): SealedTrait[Typeclass, A] =
+      SealedTrait(
+        typeInfo[A],
+        IArray(getSubtypes[A, m.MirroredElemTypes](m)*),
+        IArray.from(anns[A]),
+        IArray(paramTypeAnns[A]*),
+        isEnum[A],
+        IArray.from(inheritedAnns[A])
+      )
+
+    protected transparent inline def getSubtypes[A, SubtypeTuple <: Tuple](
+        m: Mirror.SumOf[A],
+        idx: Int = 0
+    ): List[SealedTrait.Subtype[Typeclass, A, _]] =
+      inline erasedValue[SubtypeTuple] match
+        case _: EmptyTuple =>
+          Nil
+        case _: (s *: tail) =>
+          new SealedTrait.Subtype(
+            typeInfo[s],
+            IArray.from(anns[s]),
+            IArray.from(inheritedAnns[s]),
+            IArray.from(paramTypeAnns[A]),
+            isObject[s],
+            idx,
+            CallByNeed(summonFrom {
+              case tc: Typeclass[`s`] => tc
+              case _ => deriveSubtype(summonInline[Mirror.Of[s]])
+            }),
+            x => m.ordinal(x) == idx,
+            _.asInstanceOf[s & A]
+          ) :: getSubtypes[A, tail](m, idx + 1)

--- a/src/core/magnolia.scala
+++ b/src/core/magnolia.scala
@@ -60,7 +60,7 @@ end ProductDerivation
 
 trait Derivation[TypeClass[_]]
     extends CommonDerivation[TypeClass]
-    with SealedTraitDerivation[TypeClass]:
+    with SealedTraitDerivation:
   def split[T](ctx: SealedTrait[Typeclass, T]): Typeclass[T]
 
   transparent inline def subtypes[T, SubtypeTuple <: Tuple](

--- a/src/core/magnolia.scala
+++ b/src/core/magnolia.scala
@@ -12,7 +12,7 @@ trait CommonDerivation[TypeClass[_]]:
 
   inline def derivedMirrorProduct[A](
       product: Mirror.ProductOf[A]
-  ): Typeclass[A] = join(Impl.getCaseClass(product))
+  ): Typeclass[A] = join(CaseClassDerivation.fromMirror(product))
 
   inline def getParams__[T, Labels <: Tuple, Params <: Tuple](
       annotations: Map[String, List[Any]],
@@ -21,7 +21,7 @@ trait CommonDerivation[TypeClass[_]]:
       repeated: Map[String, Boolean],
       defaults: Map[String, Option[() => Any]],
       idx: Int = 0
-  ): List[CaseClass.Param[Typeclass, T]] = Impl.getParams(
+  ): List[CaseClass.Param[Typeclass, T]] = CaseClassDerivation.paramsFromMaps(
     annotations,
     inheritedAnnotations,
     typeAnnotations,
@@ -60,17 +60,17 @@ end ProductDerivation
 
 trait Derivation[TypeClass[_]]
     extends CommonDerivation[TypeClass]
-    with Impl.Subtypes:
+    with SealedTraitDerivation[TypeClass]:
   def split[T](ctx: SealedTrait[Typeclass, T]): Typeclass[T]
 
   transparent inline def subtypes[T, SubtypeTuple <: Tuple](
       m: Mirror.SumOf[T],
       idx: Int = 0
   ): List[SealedTrait.Subtype[Typeclass, T, _]] =
-    getSubtypes[T, SubtypeTuple](m, idx)
+    subtypesFromMirror[T, SubtypeTuple](m, idx)
 
   inline def derivedMirrorSum[A](sum: Mirror.SumOf[A]): Typeclass[A] =
-    split(getSealedTrait(sum))
+    split(sealedTraitFromMirror(sum))
 
   inline def derivedMirror[A](using mirror: Mirror.Of[A]): Typeclass[A] =
     inline mirror match


### PR DESCRIPTION
Move implementation out of Derivation for easier reuse in case a different interface is needed