### PR TITLE
Readme fix for Scala2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,8 +47,6 @@ The derivation typeclass for a `Show` typeclass might look like this:
 import language.experimental.macros, magnolia1._
 
 object ShowDerivation {
-  type Typeclass[T] = Show[T]
-  
   def join[T](ctx: CaseClass[Show, T]): Show[T] = new Show[T] {
     def show(value: T): String = ctx.parameters.map { p =>
       s"${p.label}=${p.typeclass.show(p.dereference(value))}"


### PR DESCRIPTION
The `Typeclass` type alias is confusing, as it's unused. When I read the documentation, I wondered if that type alias is needed by the macro or something 🙂