### PR TITLE
Removing ThreadLocals on finish to clean up CompileTimeStack.

### DIFF
--- a/core/src/main/scala/magnolia1/magnolia.scala
+++ b/core/src/main/scala/magnolia1/magnolia.scala
@@ -903,8 +903,8 @@ private[magnolia1] object CompileTimeState {
       val depth = c.enclosingMacros.count(m => workSet(m.macroApplication.symbol))
       try fn(stack.asInstanceOf[Stack[c.type]], depth)
       finally if (depth <= 1) {
-        stack.clear()
-        workSet.clear()
+        threadLocalStack.remove()
+        threadLocalWorkSet.remove()
       }
     }
   }


### PR DESCRIPTION
This change fixes the issue with the Scala compiler server OOM mentioned in #216 .