### PR TITLE
Add isSingletonCasesEnum flag

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.softwaremill.UpdateVersionInDocs
 import com.softwaremill.SbtSoftwareMillCommon.commonSmlBuildSettings
 import com.softwaremill.Publish.{updateDocs, ossPublishSettings}
 
-val scala3 = "3.2.1"
+val scala3 = "3.2.2"
 
 ThisBuild / dynverTagPrefix := "scala3-v" // a custom prefix is needed to differentiate tags between scala2 & scala3 versions
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.1
+sbt.version=1.8.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.8.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,6 @@ addSbtPlugin(
   "com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-publish" % sbtSoftwareMillVersion
 )
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.9")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,5 @@ addSbtPlugin(
 )
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.9")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.10")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")

--- a/src/core/impl.scala
+++ b/src/core/impl.scala
@@ -113,6 +113,7 @@ trait SealedTraitDerivation:
       IArray.from(anns[A]),
       IArray(paramTypeAnns[A]*),
       isEnum[A],
+      isSingletonCasesEnum[A],
       IArray.from(inheritedAnns[A])
     )
 

--- a/src/core/interface.scala
+++ b/src/core/interface.scala
@@ -201,6 +201,7 @@ case class SealedTrait[Typeclass[_], Type](
     annotations: IArray[Any],
     typeAnnotations: IArray[Any],
     isEnum: Boolean,
+    isSingletonCasesEnum: Boolean,
     inheritedAnnotations: IArray[Any]
 ) extends Serializable:
 
@@ -217,6 +218,7 @@ case class SealedTrait[Typeclass[_], Type](
     annotations,
     typeAnnotations,
     isEnum,
+    false,
     IArray.empty[Any]
   )
 
@@ -233,6 +235,7 @@ case class SealedTrait[Typeclass[_], Type](
     annotations,
     typeAnnotations,
     isEnum,
+    false,
     this.inheritedAnnotations
   )
 
@@ -283,6 +286,7 @@ object SealedTrait:
     annotations,
     typeAnnotations,
     isEnum,
+    false,
     IArray.empty[Any]
   )
 

--- a/src/core/macro.scala
+++ b/src/core/macro.scala
@@ -33,7 +33,9 @@ object Macro:
   
   def isSingletonCasesEnum[T: Type](using Quotes): Expr[Boolean] =
     import quotes.reflect.*
-    Expr(TypeRepr.of[T].typeSymbol.companionClass.methodMember("values").nonEmpty)
+
+    val ts = TypeRepr.of[T].typeSymbol
+    Expr(ts.flags.is(Flags.Enum) && ts.companionClass.methodMember("values").nonEmpty)
 
   def anns[T: Type](using Quotes): Expr[List[Any]] =
     new CollectAnnotations[T].anns

--- a/src/core/macro.scala
+++ b/src/core/macro.scala
@@ -5,6 +5,7 @@ import scala.quoted.*
 object Macro:
   inline def isObject[T]: Boolean = ${ isObject[T] }
   inline def isEnum[T]: Boolean = ${ isEnum[T] }
+  inline def isSingletonCasesEnum[T]: Boolean = ${ isSingletonCasesEnum[T] }
   inline def anns[T]: List[Any] = ${ anns[T] }
   inline def inheritedAnns[T]: List[Any] = ${ inheritedAnns[T] }
   inline def typeAnns[T]: List[Any] = ${ typeAnns[T] }
@@ -29,6 +30,10 @@ object Macro:
     import quotes.reflect.*
 
     Expr(TypeRepr.of[T].typeSymbol.flags.is(Flags.Enum))
+  
+  def isSingletonCasesEnum[T: Type](using Quotes): Expr[Boolean] =
+    import quotes.reflect.*
+    Expr(TypeRepr.of[T].typeSymbol.companionClass.methodMember("values").nonEmpty)
 
   def anns[T: Type](using Quotes): Expr[List[Any]] =
     new CollectAnnotations[T].anns

--- a/src/examples/SubtypeInfo.scala
+++ b/src/examples/SubtypeInfo.scala
@@ -7,6 +7,7 @@ trait SubtypeInfo[T] {
   def traitAnnotations: Seq[Any]
   def subtypeAnnotations: Seq[Seq[Any]]
   def isEnum: Boolean
+  def isSingletonCasesEnum: Boolean
 }
 
 object SubtypeInfo extends Derivation[SubtypeInfo]:
@@ -16,6 +17,7 @@ object SubtypeInfo extends Derivation[SubtypeInfo]:
       def traitAnnotations: List[Any] = Nil
       def subtypeAnnotations: List[List[Any]] = Nil
       def isEnum: Boolean = false
+      def isSingletonCasesEnum: Boolean = false
 
   override def split[T](ctx: SealedTrait[SubtypeInfo, T]): SubtypeInfo[T] =
     new SubtypeInfo[T]:
@@ -24,6 +26,7 @@ object SubtypeInfo extends Derivation[SubtypeInfo]:
       def subtypeAnnotations: Seq[Seq[Any]] =
         ctx.subtypes.map(_.annotations.toList).toList
       def isEnum: Boolean = ctx.isEnum
+      def isSingletonCasesEnum: Boolean = ctx.isSingletonCasesEnum
 
   given fallback[T]: SubtypeInfo[T] =
     new SubtypeInfo[T]:
@@ -31,3 +34,4 @@ object SubtypeInfo extends Derivation[SubtypeInfo]:
       def traitAnnotations: Seq[Any] = Nil
       def subtypeAnnotations: Seq[Seq[Any]] = Nil
       def isEnum: Boolean = false
+      def isSingletonCasesEnum: Boolean = false

--- a/src/test/SumsTests.scala
+++ b/src/test/SumsTests.scala
@@ -50,6 +50,17 @@ class SumsTests extends munit.FunSuite:
     assertEquals(derivedSubtypeInfo.isEnum, false)
   }
 
+  test("isSingletonCasesEnum field in SubtypeInfo should be true for singleton cases only enum") {
+    assertEquals(SubtypeInfo.derived[Size].isSingletonCasesEnum, true)
+    assertEquals(SubtypeInfo.derived[Planet].isSingletonCasesEnum, true)
+    assertEquals(SubtypeInfo.derived[ExtendingTraits].isSingletonCasesEnum, true)
+  }
+
+  test("isSingletonCasesEnum field in SubtypeInfo should be false for enum with non-singleton cases") {
+    assertEquals(SubtypeInfo.derived[Sport].isSingletonCasesEnum, false)
+    assertEquals(SubtypeInfo.derived[OptInt].isSingletonCasesEnum, false)
+  }
+
   test("construct a Show instance for an enum") {
     val res = Show.derived[Size].show(Size.S)
     assertEquals(res, "S()")
@@ -181,7 +192,14 @@ object SumsTests:
 
   enum Size:
     case S, M, L
+  
+  enum Planet(mass: Double, radius: Double):
+    case Earth extends Planet(5.976e+24, 6.37814e6)
+    case Mars extends Planet(6.421e+23, 3.3972e6)
 
+  enum OptInt:
+    case Some(x: Int)
+    case None
  
   sealed trait Sport
   case object Boxing extends Sport


### PR DESCRIPTION
It is useful to disambiguate between "singleton cases"/simple enums and ADTs.

My concrete use case was JSON serialization:
- simple enums get written as simple strings
- ADTs get written as objects with `@type`  field, and other fields if they have them

Implementation-wise, the [official docs](https://docs.scala-lang.org/scala3/reference/enums/desugarEnums.html#translation-of-enums-with-singleton-cases) say that only "singleton cases" enums will have a `values` method.