### PR TITLE
Dealias types when deriving names (Scala 3)

### DIFF
--- a/src/core/macro.scala
+++ b/src/core/macro.scala
@@ -137,11 +137,11 @@ object Macro:
 
     def normalizedName(s: Symbol): String =
       if s.flags.is(Flags.Module) then s.name.stripSuffix("$") else s.name
-    def name(tpe: TypeRepr): Expr[String] = tpe match
-      case TermRef(typeRepr, name) if tpe.typeSymbol.flags.is(Flags.Module) =>
+    def name(tpe: TypeRepr): Expr[String] = tpe.dealias match
+      case matchedTpe @ TermRef(typeRepr, name) if matchedTpe.typeSymbol.flags.is(Flags.Module) =>
         Expr(name.stripSuffix("$"))
       case TermRef(typeRepr, name) => Expr(name)
-      case _                       => Expr(normalizedName(tpe.typeSymbol))
+      case matchedTpe              => Expr(normalizedName(matchedTpe.typeSymbol))
 
     def ownerNameChain(sym: Symbol): List[String] =
       if sym.isNoSymbol then List.empty
@@ -151,7 +151,7 @@ object Macro:
       else ownerNameChain(sym.owner) :+ normalizedName(sym)
 
     def owner(tpe: TypeRepr): Expr[String] = Expr(
-      ownerNameChain(tpe.typeSymbol.maybeOwner).mkString(".")
+      ownerNameChain(tpe.dealias.typeSymbol.maybeOwner).mkString(".")
     )
 
     def typeInfo(tpe: TypeRepr): Expr[TypeInfo] = tpe match
@@ -164,7 +164,7 @@ object Macro:
           )
         }
       case _ =>
-        '{ TypeInfo(${ owner(tpe) }, ${ name(tpe.dealias) }, Nil) }
+        '{ TypeInfo(${ owner(tpe) }, ${ name(tpe) }, Nil) }
 
     typeInfo(TypeRepr.of[T])
 

--- a/src/core/macro.scala
+++ b/src/core/macro.scala
@@ -164,7 +164,7 @@ object Macro:
           )
         }
       case _ =>
-        '{ TypeInfo(${ owner(tpe) }, ${ name(tpe) }, Nil) }
+        '{ TypeInfo(${ owner(tpe) }, ${ name(tpe.dealias) }, Nil) }
 
     typeInfo(TypeRepr.of[T])
 

--- a/src/test/ProductsTests.scala
+++ b/src/test/ProductsTests.scala
@@ -180,6 +180,18 @@ class ProductsTests extends munit.FunSuite:
     assertEquals(res.full, "magnolia1.tests.ProductsTests.Fruit")
   }
 
+  test("case class parameter typeName should be dealiased") {
+    given stringTypeName: TypeNameInfo[String] with {
+      def name = ???
+
+      def subtypeNames = ???
+    }
+    val res1 = TypeNameInfo.derived[Parameterized[Domain1.Type]].name
+    val res2 = TypeNameInfo.derived[Parameterized[Domain2.Type]].name
+    assertEquals(res1.typeParams.head.short, "Int")
+    assertEquals(res2.typeParams.head.short, "String")
+  }
+
   test("show chained error stack when leaf instance is missing") {
     val error = compileErrors("Show.derived[Schedule]")
     assert(
@@ -266,5 +278,15 @@ object ProductsTests:
 
   case class Fruit(name: String)
 
+  case class Parameterized[T](t: T)
+
+  object Domain1:
+    type Type = Int
+
+  object Domain2:
+    type Type = String
+
   object Fruit:
     given showFruit: Show[String, Fruit] = (f: Fruit) => f.name
+
+

--- a/src/test/ProductsTests.scala
+++ b/src/test/ProductsTests.scala
@@ -288,5 +288,3 @@ object ProductsTests:
 
   object Fruit:
     given showFruit: Show[String, Fruit] = (f: Fruit) => f.name
-
-


### PR DESCRIPTION
Fixes #467 for Scala 3

This PR ensures that type names are derived from dealiased underlying types.
Inspired by an issue reported in tapir:

```scala
//> using scala 3.3.0-RC6
//> using dep com.softwaremill.sttp.tapir::tapir-core:1.4.0
import sttp.tapir.*
import sttp.tapir.generic.auto.*

case class Foo[T](t: T)

object Domain1:
  type Type = Int

object Domain2:
  type Type = String

@main
def main =
  val d1Schema = summon[Schema[Foo[Domain1.Type]]]
  val d2Schema = summon[Schema[Foo[Domain2.Type]]]
  println(d1Schema.name.map(_.show)) // Some(.Foo[Type]), should be Some(.Foo[Int])
  println(d2Schema.name.map(_.show)) // Some(.Foo[Type]), should be Some(.Foo[String])
```

This issue doesn't happen for Scala 2, where dealiasing seems to be correctly applied.