### PR TITLE
[bugfix] Suppress unsafe type check warning

### DIFF
--- a/src/core/impl.scala
+++ b/src/core/impl.scala
@@ -78,7 +78,7 @@ object CaseClassDerivation:
       case _: (EmptyTuple, EmptyTuple) =>
         Nil
       case _: ((l *: ltail), (p *: ptail)) =>
-        def safeCast(any: Any) = Option.when(any == null || any.isInstanceOf[p])(any.asInstanceOf[p])
+        def safeCast(any: Any) = Option.when(any == null || (any: @unchecked).isInstanceOf[p])(any.asInstanceOf[p])
 
         val label = constValue[l].asInstanceOf[String]
         CaseClass.Param[Typeclass, A, p](

--- a/src/test/DefaultValuesTests.scala
+++ b/src/test/DefaultValuesTests.scala
@@ -42,12 +42,19 @@ class DefaultValuesTests extends munit.FunSuite:
     assertEquals(res, Right(ParamsWithDefaultGeneric("A", 0)))
   }
 
+  // Fails because safeCast in impl works on Any, which casts Option[Int] to Option[String]
+  // test("construct a HasDefault instance for a generic product with default generic values") {
+  //   val res = HasDefault.derived[ParamsWithDefaultDeepGeneric[String, Int]].defaultValue
+  //   assertEquals(res, Right(ParamsWithDefaultDeepGeneric(Some("A"), None)))
+  // }
+
 object DefaultValuesTests:
 
   case class ParamsWithDefault(a: Int = 3, b: Int = 4)
 
   case class ParamsWithDefaultGeneric[A, B](a: A = "A", b: B = "B")
 
+  case class ParamsWithDefaultDeepGeneric[A, B](a: Option[A] = Some("A"), b: Option[B] = Some("B"))
   case class Item(name: String, quantity: Int = 1, price: Int)
 
   case class WithDefault(x: Int = 2)


### PR DESCRIPTION
This fix removes a warning, which happens for Magnolia usages on generic types in case class params. The casting is generally safe except when there are default values overridden with different type, which is probably a very rare situation. A proper fix would require a broader change, touching the way default values are resolved, which doesn't seem worth pursuing at the moment. For the record, I added a commented test to reflect this case.