### PR TITLE
Split subtypes array initialization to multiple functions.

### DIFF
--- a/core/src/main/scala/magnolia1/magnolia.scala
+++ b/core/src/main/scala/magnolia1/magnolia.scala
@@ -673,12 +673,12 @@ object Magnolia {
           .unzip
 
         val subtypesVal = c.freshName(TermName("subtypes"))
-        val combineArrays = functionNames.map(name => q"""$subtypesVal ++= $name""")
+        val combinations = functionNames.map(name => q"""$subtypesVal ++= $name""")
 
         Some(q"""{
           ..$partialAssignmentFunctions
           val $subtypesVal = Array.newBuilder[$subType]
-          ..$combineArrays
+          ..$combinations
           $typeNameDef
           ${c.prefix}.split(new $SealedTraitSym(
             $typeName,

--- a/examples/src/main/scala/magnolia1/examples/print.scala
+++ b/examples/src/main/scala/magnolia1/examples/print.scala
@@ -25,7 +25,7 @@ trait GenericPrint {
     }
   }
 
-  def split[T](ctx: SealedTrait[Print, T])(): Print[T] = { value =>
+  def split[T](ctx: SealedTrait[Print, T]): Print[T] = { value =>
     ctx.split(value) { sub =>
       sub.typeclass.print(sub.cast(value))
     }


### PR DESCRIPTION
We are using Magnolia in production and mainly use it to derive the parent type's type class instances from the type class instances of subtypes. One of our types has more than 700 subtypes, and when derives typeclass instances of this type, the process of initializing the huge subtypes array is performed in a single method, resulting in a "Method too large" compilation error. This PR splits the initialization of the subtypes array into multiple functions and calls each function at the end to combine the array. This method also increases the size of the method, but to a much slower degree, so I think it's still worthwhile. I would appreciate it if you could review it.