### PR TITLE
Reduce constant pool usage, this make Magnolia able to derive instance for sealed trait that has a lot of subtypes 

### DIFF
--- a/core/src/main/scala/magnolia1/magnolia.scala
+++ b/core/src/main/scala/magnolia1/magnolia.scala
@@ -394,8 +394,9 @@ object Magnolia {
           $impl
       """
 
-      def constructPartialAssignmentFunction(typeclasses: List[(Type, Tree)], arrayElementType: Type): (TermName, Tree) = {
-        val functionName = c.freshName(TermName("partialAssignments"))
+      def constructPartialAssignmentFunction(typeclasses: List[(Type, Tree)], arrayElementType: Type): (Tree, Tree) = {
+        val objectName = c.freshName(TermName("PartialAssignments"))
+        val functionName = c.freshName(TermName("func"))
         val arrayVal = c.freshName(TermName("arr"))
         val startVal = c.freshName(TermName("start"))
         val assignments = typeclasses.zipWithIndex.map { case ((subType, typeclass), idx) =>
@@ -414,12 +415,15 @@ object Magnolia {
         }
         val arrayTpe = appliedType(ArrayTpe, arrayElementType)
         val tree =
-          q"""def $functionName($arrayVal: $arrayTpe, $startVal: $IntTpe) = {
+          q"""
+              object $objectName {
+                def $functionName($arrayVal: $arrayTpe, $startVal: $IntTpe) = {
               ..$assignments
+              }
             }
           """
 
-        (functionName, tree)
+        (q"""$objectName.$functionName""", tree)
       }
 
       val result = if (isRefinedType) {


### PR DESCRIPTION
Even after #485 has been merged, I found that there is a limit to the number of subtypes when deriving instances with the `split`. By splitting subtypes array initialization to multiple functions, we are able to avoid `method too large` error, but we aren't able to avoid `class too large` error because of `constant pool` limit. When we initialize `Subtype`, we pass a lot of values, so we consume `constant pool` a lot which has 65534 entries.
When I tested like below, the limitation of the number of subtypes is about 1550 with current implementation.

```
trait Print {
 ...
}

trait GenericPrint {
   ... 
}

sealed trait Event

case class AEvent(...) extends Event
... // variants

object Instances extends GenericPrint {
    implicit val aEventInstance = ...
    ... // instances of subtypes

    implicit val eventInstance = gen[Event]
}
```
With this PR, we can derive instance for type has about 3600 subtypes and it seems there is no compilation speed degradation.