### PR TITLE
Add filter for `jdk.internal` annotations

### DIFF
--- a/src/core/macro.scala
+++ b/src/core/macro.scala
@@ -266,6 +266,6 @@ object Macro:
 
     private def filterAnnotation(a: Term): Boolean =
       a.tpe.typeSymbol.maybeOwner.isNoSymbol ||
-        a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" ||
-        a.tpe.typeSymbol.owner.fullName != "jdk.internal"
+        (a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" &&
+          a.tpe.typeSymbol.owner.fullName != "jdk.internal")
   }

--- a/src/core/macro.scala
+++ b/src/core/macro.scala
@@ -266,5 +266,6 @@ object Macro:
 
     private def filterAnnotation(a: Term): Boolean =
       a.tpe.typeSymbol.maybeOwner.isNoSymbol ||
-        a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal"
+        a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" ||
+        a.tpe.typeSymbol.owner.fullName != "jdk.internal"
   }


### PR DESCRIPTION
Fixes #493

I haven't added a test for this case since the CI is run on JDK11 only. Do you prefer if I add a test as in the issue repro in the issue above?