### PR TITLE
Fix providing annotations vs inherited annotations

### DIFF
--- a/core/src/main/scala/magnolia1/macro.scala
+++ b/core/src/main/scala/magnolia1/macro.scala
@@ -240,11 +240,11 @@ object Macro:
             .filterNot(isObjectOrScala)
             .collect {
               case s if s != tpe.typeSymbol =>
-                (fromConstructor(s) ++ fromDeclarations(s)).filter { case (_, anns) =>
+                (fromConstructor(s)).filter { case (_, anns) =>
                   anns.nonEmpty
                 }
             }
-            .flatten
+            .flatten ++ fromDeclarations(tpe.typeSymbol, inherited = true)
         }
       }
 
@@ -256,10 +256,11 @@ object Macro:
       }
 
     private def fromDeclarations(
-        from: Symbol
+        from: Symbol,
+        inherited: Boolean = false
     ): List[(String, List[Expr[Any]])] =
       from.fieldMembers.collect { case field: Symbol =>
-        val annotations = field.annotations ::: field.allOverriddenSymbols.flatMap(_.annotations).toList
+        val annotations = if (!inherited) field.annotations else field.allOverriddenSymbols.flatMap(_.annotations).toList
         field.name -> annotations
           .filter(filterAnnotation)
           .map(_.asExpr.asInstanceOf[Expr[Any]])

--- a/examples/src/main/scala/magnolia1/examples/show.scala
+++ b/examples/src/main/scala/magnolia1/examples/show.scala
@@ -26,7 +26,7 @@ trait GenericShow[Out] extends AutoDerivation[[X] =>> Show[Out, X]] {
           if (param.annotations.isEmpty && param.inheritedAnnotations.isEmpty)
             ""
           else {
-            (param.annotations ++ param.inheritedAnnotations).distinct
+            (param.annotations.map(_.toString) ++ param.inheritedAnnotations.map(a => s"[i]$a")).distinct
               .mkString("{", ",", "}")
           }
 

--- a/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
+++ b/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
@@ -25,7 +25,7 @@ class AnnotationsTests extends munit.FunSuite:
     val res = Show.derived[Pet].show(Dog("Alex", 10, likesMeat = true))
     assertEquals(
       res,
-      "{MyTypeAnnotation(2),MyTypeAnnotation(1)}Dog{MyTypeAnnotation(2),MyTypeAnnotation(1)}(name{MyAnnotation(1)}=Alex,age{MyAnnotation(2)}=10,likesMeat{MyAnnotation(3)}=true)"
+      "{MyTypeAnnotation(2),MyTypeAnnotation(1)}Dog{MyTypeAnnotation(2),MyTypeAnnotation(1)}(name{[i]MyAnnotation(1)}=Alex,age{[i]MyAnnotation(2)}=10,likesMeat{MyAnnotation(3)}=true)"
     )
   }
 
@@ -35,13 +35,13 @@ class AnnotationsTests extends munit.FunSuite:
       .show(Hamster("Alex", 10, likesNuts = true, likesVeggies = true))
     assertEquals(
       res,
-      "{MyTypeAnnotation(1)}Hamster{MyTypeAnnotation(1)}(name{MyAnnotation(1)}=Alex,age{MyAnnotation(2)}=10,likesNuts{MyAnnotation(3)}=true,likesVeggies{MyAnnotation(4)}=true)"
+      "{MyTypeAnnotation(1)}Hamster{MyTypeAnnotation(1)}(name{[i]MyAnnotation(1)}=Alex,age{MyAnnotation(6),[i]MyAnnotation(2)}=10,likesNuts{[i]MyAnnotation(3)}=true,likesVeggies{MyAnnotation(4)}=true)"
     )
   }
 
   test("inherit annotations from base class constructor parameters") {
     val res = Show.derived[Foo].show(Foo("foo"))
-    assertEquals(res, "Foo(foo{MyAnnotation(2),MyAnnotation(1)}=foo)")
+    assertEquals(res, "Foo(foo{MyAnnotation(2),[i]MyAnnotation(1)}=foo)")
   }
 
   test(
@@ -50,7 +50,7 @@ class AnnotationsTests extends munit.FunSuite:
     val res = Show.derived[Bar].show(Bar("foo", "bar"))
     assertEquals(
       res,
-      "Bar(foo{MyAnnotation(2),MyAnnotation(1)}=foo,bar{MyAnnotation(2),MyAnnotation(1)}=bar)"
+      "Bar(foo{MyAnnotation(2),[i]MyAnnotation(1)}=foo,bar{MyAnnotation(2),[i]MyAnnotation(1)}=bar)"
     )
   }
 
@@ -156,6 +156,7 @@ object AnnotationsTests:
 
   case class Hamster(
       name: String,
+      @MyAnnotation(6) 
       age: Int,
       likesNuts: Boolean,
       @MyAnnotation(4) likesVeggies: Boolean

--- a/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
+++ b/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
@@ -156,7 +156,7 @@ object AnnotationsTests:
 
   case class Hamster(
       name: String,
-      @MyAnnotation(6) 
+      @MyAnnotation(6)
       age: Int,
       likesNuts: Boolean,
       @MyAnnotation(4) likesVeggies: Boolean


### PR DESCRIPTION
PR https://github.com/softwaremill/magnolia/pull/525 introduced changes to `CollectAnnotations.fromDeclarations`, causing incorrect creation of annotation list for class fields which override base trait fields: `inheritedAnns` returns an empty list, while `anns` returns a list containing both field annotations and inherited annotations.
This problem slipped through tests, as we use a `Show` derivation which prints strings without differentiating field/inherited annotations. The issue has been detected in Tapir schema derivation tests.

This PR adjusts tests to include this distinction and fixes annotation extraction methods.