### PR TITLE
[scala2] feat: adding on-demand default evaluation

### DIFF
--- a/core/src/main/scala/magnolia1/interface.scala
+++ b/core/src/main/scala/magnolia1/interface.scala
@@ -296,6 +296,8 @@ trait Param[Typeclass[_], Type] extends ReadOnlyParam[Typeclass, Type] {
   /** provides the default value for this parameter, as defined in the case class constructor */
   def default: Option[PType]
 
+  def dynamicDefault: Option[() => PType]
+
   override def toString: String = s"Param($label)"
 }
 
@@ -322,6 +324,9 @@ object Param {
     def typeName: TypeName = typeNameParam
     def index: Int = idx
     def repeated: Boolean = isRepeated
+    def dynamicDefault: Option[() => PType] = defaultVal.uncalledValue().fold[Option[() => PType]](None) { _ =>
+      Some(() => defaultVal.uncalledValue().get)
+    }
     def default: Option[PType] = defaultVal.value
     def typeclass: Tc[PType] = typeclassParam.value
     def dereference(t: T): PType = t.asInstanceOf[Product].productElement(idx).asInstanceOf[PType]
@@ -346,6 +351,9 @@ object Param {
     def typeName: TypeName = typeNameParam
     def index: Int = idx
     def repeated: Boolean = isRepeated
+    def dynamicDefault: Option[() => PType] = defaultVal.uncalledValue().fold[Option[() => PType]](None) { _ =>
+      Some(() => defaultVal.uncalledValue().get)
+    }
     def default: Option[PType] = defaultVal.value
     def typeclass: Tc[PType] = typeclassParam.value
     def dereference(t: T): PType = t.asInstanceOf[Product].productElement(idx).asInstanceOf[PType]
@@ -370,6 +378,9 @@ object Param {
     def typeName: TypeName = typeNameParam
     def index: Int = 0
     def repeated: Boolean = isRepeated
+    def dynamicDefault: Option[() => PType] = defaultVal.uncalledValue().fold[Option[() => PType]](None) { _ =>
+      Some(() => defaultVal.uncalledValue().get)
+    }
     def default: Option[PType] = defaultVal.value
     def typeclass: Tc[PType] = typeclassParam.value
     def dereference(t: T): PType = deref(t)
@@ -394,6 +405,9 @@ object Param {
     def typeName: TypeName = typeNameParam
     def index: Int = 0
     def repeated: Boolean = isRepeated
+    def dynamicDefault: Option[() => PType] = defaultVal.uncalledValue().fold[Option[() => PType]](None) { _ =>
+      Some(() => defaultVal.uncalledValue().get)
+    }
     def default: Option[PType] = defaultVal.value
     def typeclass: Tc[PType] = typeclassParam.value
     def dereference(t: T): PType = deref(t)

--- a/core/src/main/scala/magnolia1/interface.scala
+++ b/core/src/main/scala/magnolia1/interface.scala
@@ -296,7 +296,7 @@ trait Param[Typeclass[_], Type] extends ReadOnlyParam[Typeclass, Type] {
   /** provides the default value for this parameter, as defined in the case class constructor */
   def default: Option[PType]
 
-  def evaluateDefault: Option[() => PType]
+  def evaluateDefault: Option[() => PType] = None
 
   override def toString: String = s"Param($label)"
 }
@@ -324,7 +324,7 @@ object Param {
     def typeName: TypeName = typeNameParam
     def index: Int = idx
     def repeated: Boolean = isRepeated
-    def evaluateDefault: Option[() => PType] = getDefaultEvaluatorFromDefaultVal(defaultVal)
+    override def evaluateDefault: Option[() => PType] = getDefaultEvaluatorFromDefaultVal(defaultVal)
     def default: Option[PType] = defaultVal.value
     def typeclass: Tc[PType] = typeclassParam.value
     def dereference(t: T): PType = t.asInstanceOf[Product].productElement(idx).asInstanceOf[PType]
@@ -349,7 +349,7 @@ object Param {
     def typeName: TypeName = typeNameParam
     def index: Int = idx
     def repeated: Boolean = isRepeated
-    def evaluateDefault: Option[() => PType] = getDefaultEvaluatorFromDefaultVal(defaultVal)
+    override def evaluateDefault: Option[() => PType] = getDefaultEvaluatorFromDefaultVal(defaultVal)
     def default: Option[PType] = defaultVal.value
     def typeclass: Tc[PType] = typeclassParam.value
     def dereference(t: T): PType = t.asInstanceOf[Product].productElement(idx).asInstanceOf[PType]
@@ -374,7 +374,7 @@ object Param {
     def typeName: TypeName = typeNameParam
     def index: Int = 0
     def repeated: Boolean = isRepeated
-    def evaluateDefault: Option[() => PType] = getDefaultEvaluatorFromDefaultVal(defaultVal)
+    override def evaluateDefault: Option[() => PType] = getDefaultEvaluatorFromDefaultVal(defaultVal)
     def default: Option[PType] = defaultVal.value
     def typeclass: Tc[PType] = typeclassParam.value
     def dereference(t: T): PType = deref(t)
@@ -399,7 +399,7 @@ object Param {
     def typeName: TypeName = typeNameParam
     def index: Int = 0
     def repeated: Boolean = isRepeated
-    def evaluateDefault: Option[() => PType] = getDefaultEvaluatorFromDefaultVal(defaultVal)
+    override def evaluateDefault: Option[() => PType] = getDefaultEvaluatorFromDefaultVal(defaultVal)
     def default: Option[PType] = defaultVal.value
     def typeclass: Tc[PType] = typeclassParam.value
     def dereference(t: T): PType = deref(t)

--- a/core/src/main/scala/magnolia1/interface.scala
+++ b/core/src/main/scala/magnolia1/interface.scala
@@ -296,6 +296,7 @@ trait Param[Typeclass[_], Type] extends ReadOnlyParam[Typeclass, Type] {
   /** provides the default value for this parameter, as defined in the case class constructor */
   def default: Option[PType]
 
+  /** provides a function to evaluate the default value for this parameter, as defined in the case class constructor */
   def evaluateDefault: Option[() => PType] = None
 
   override def toString: String = s"Param($label)"

--- a/core/src/main/scala/magnolia1/magnolia.scala
+++ b/core/src/main/scala/magnolia1/magnolia.scala
@@ -963,6 +963,9 @@ object CallByNeed {
 // The supportDynamicValueEvaluation is passed as a function so that it can be nullified. Otherwise, there is no need for the function value.
 final class CallByNeed[+A] private (private[this] var eval: () => A, private var supportDynamicValueEvaluation: () => Boolean)
     extends Serializable {
+
+  def this(eval: () => A) = this(eval, () => false)
+
   val valueEvaluator: Option[() => A] = {
     val finalRes = if (supportDynamicValueEvaluation()) {
       val res = Some(eval.fv)

--- a/core/src/main/scala/magnolia1/magnolia.scala
+++ b/core/src/main/scala/magnolia1/magnolia.scala
@@ -5,6 +5,7 @@ import magnolia1.Monadic.Ops
 import scala.annotation.{compileTimeOnly, tailrec}
 import scala.collection.mutable
 import scala.language.higherKinds
+import scala.reflect.ClassTag
 import scala.reflect.macros._
 
 /** the object which defines the Magnolia macro */
@@ -946,6 +947,7 @@ private[magnolia1] object CompileTimeState {
 
 object CallByNeed { def apply[A](a: => A): CallByNeed[A] = new CallByNeed(() => a) }
 final class CallByNeed[+A](private[this] var eval: () => A) extends Serializable {
+  val uncalledValue: () => A = eval.fv
   lazy val value: A = {
     val result = eval()
     eval = null

--- a/core/src/main/scala/magnolia1/magnolia.scala
+++ b/core/src/main/scala/magnolia1/magnolia.scala
@@ -5,7 +5,6 @@ import magnolia1.Monadic.Ops
 import scala.annotation.{compileTimeOnly, tailrec}
 import scala.collection.mutable
 import scala.language.higherKinds
-import scala.reflect.ClassTag
 import scala.reflect.macros._
 
 /** the object which defines the Magnolia macro */

--- a/core/src/main/scala/magnolia1/magnolia.scala
+++ b/core/src/main/scala/magnolia1/magnolia.scala
@@ -946,7 +946,16 @@ private[magnolia1] object CompileTimeState {
 }
 
 object CallByNeed {
+
+  /** Initializes a class that allows for suspending evaluation of a value until it is needed. Evaluation of a value via `.value` can only
+    * happen once. Evaluation of a value via `.valueEvaluator` will return None. For evaluating a value multiple times, please construct a
+    * CallByNeed via CallByNeed.withValueEvaluator(value)
+    */
   def apply[A](a: => A): CallByNeed[A] = new CallByNeed(() => a, () => false)
+
+  /** Initializes a class that allows for suspending evaluation of a value until it is needed. Evaluation of a value via `.value` can only
+    * happen once. Evaluation of a value via `.valueEvaluator.map(evaluator => evaluator())` will happen every time the evaluator is called
+    */
   def withValueEvaluator[A](a: => A): CallByNeed[A] = new CallByNeed(() => a, () => true)
 }
 

--- a/core/src/main/scala/magnolia1/magnolia.scala
+++ b/core/src/main/scala/magnolia1/magnolia.scala
@@ -963,6 +963,7 @@ object CallByNeed {
 final class CallByNeed[+A] private (private[this] var eval: () => A, private var supportDynamicValueEvaluation: () => Boolean)
     extends Serializable {
 
+  // This second constructor is necessary to support backwards compatibility for v1.1.9 and earlier
   def this(eval: () => A) = this(eval, () => false)
 
   val valueEvaluator: Option[() => A] = {

--- a/examples/src/main/scala/magnolia1/examples/default.scala
+++ b/examples/src/main/scala/magnolia1/examples/default.scala
@@ -5,7 +5,10 @@ import magnolia1.{CaseClass, Magnolia, SealedTrait}
 import scala.language.experimental.macros
 
 /** typeclass for providing a default value for a particular type */
-trait HasDefault[T] { def defaultValue: Either[String, T] }
+trait HasDefault[T] {
+  def defaultValue: Either[String, T]
+  def getDynamicDefaultValueForParam(paramLabel: String): Option[Any] = None
+}
 
 /** companion object and derivation object for [[HasDefault]] */
 object HasDefault {
@@ -21,7 +24,15 @@ object HasDefault {
         case None      => param.typeclass.defaultValue
       }
     }
-  }
+
+    override def getDynamicDefaultValueForParam(paramLabel: String): Option[Any] =
+      ctx.parameters
+        .filter(_.label == paramLabel)
+        .flatMap(_.evaluateDefault)
+        .headOption
+        .map(res => res())
+    }
+
 
   /** chooses which subtype to delegate to */
   def split[T](ctx: SealedTrait[HasDefault, T])(): HasDefault[T] = new HasDefault[T] {
@@ -29,16 +40,26 @@ object HasDefault {
       case Some(sub) => sub.typeclass.defaultValue
       case None      => Left("no subtypes")
     }
+
+    override def getDynamicDefaultValueForParam(paramLabel: String): Option[Any] =
+      ctx.subtypes.headOption match {
+        case Some(sub) => sub.typeclass.getDynamicDefaultValueForParam(paramLabel)
+        case _ => None
+      }
   }
 
   /** default value for a string; the empty string */
   implicit val string: HasDefault[String] = new HasDefault[String] { def defaultValue = Right("") }
 
   /** default value for ints; 0 */
-  implicit val int: HasDefault[Int] = new HasDefault[Int] { def defaultValue = Right(0) }
+  implicit val int: HasDefault[Int] = new HasDefault[Int] {
+    def defaultValue = Right(0)
+  }
 
   /** oh, no, there is no default Boolean... whatever will we do? */
   implicit val boolean: HasDefault[Boolean] = new HasDefault[Boolean] { def defaultValue = Left("truth is a lie") }
+
+  implicit val double: HasDefault[Double] = new HasDefault[Double] { def defaultValue = Right(0) }
 
   /** default value for sequences; the empty sequence */
   implicit def seq[A]: HasDefault[Seq[A]] = new Typeclass[Seq[A]] { def defaultValue = Right(Seq.empty) }

--- a/examples/src/main/scala/magnolia1/examples/default.scala
+++ b/examples/src/main/scala/magnolia1/examples/default.scala
@@ -31,8 +31,7 @@ object HasDefault {
         .flatMap(_.evaluateDefault)
         .headOption
         .map(res => res())
-    }
-
+  }
 
   /** chooses which subtype to delegate to */
   def split[T](ctx: SealedTrait[HasDefault, T])(): HasDefault[T] = new HasDefault[T] {
@@ -44,7 +43,7 @@ object HasDefault {
     override def getDynamicDefaultValueForParam(paramLabel: String): Option[Any] =
       ctx.subtypes.headOption match {
         case Some(sub) => sub.typeclass.getDynamicDefaultValueForParam(paramLabel)
-        case _ => None
+        case _         => None
       }
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-publish" % 
 
 addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.1")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,5 @@ addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-publish" % 
 
 addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,3 @@ addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
-

--- a/test/src/test/scala/magnolia1/tests/tests.scala
+++ b/test/src/test/scala/magnolia1/tests/tests.scala
@@ -195,6 +195,7 @@ object Exactly {
 
 case class ParamsWithDefault(a: Int = 3, b: Int = 4)
 case class ParamsWithDefaultGeneric[A, B](a: A = "A", b: B = "B")
+case class ParamsWithDynamicDefault(a: Double = scala.math.random())
 
 sealed trait Parent
 trait BadChild extends Parent // escape hatch!
@@ -294,6 +295,20 @@ class Tests extends munit.FunSuite {
     test("construct a HasDefault instance for a generic product with default values") {
       val res = HasDefault.gen[ParamsWithDefaultGeneric[String, Int]].defaultValue
       assertEquals(res, Right(ParamsWithDefaultGeneric("A", 0)))
+    }
+
+    test("construct a HasDefault instance for a generic product with dynamic default values") {
+      val res1 = HasDefault.gen[ParamsWithDynamicDefault].getDynamicDefaultValueForParam("a")
+      val res2 = HasDefault.gen[ParamsWithDynamicDefault].getDynamicDefaultValueForParam("a")
+
+      assertEquals(res1.isDefined, true)
+      assertEquals(res2.isDefined, true)
+
+      for {
+        firstParam <- res1
+        secondParam <- res2
+        res = assertNotEquals(firstParam, secondParam)
+      } yield res
     }
 
     test("serialize a Branch") {


### PR DESCRIPTION
## Description
Currently, all default values are precompiled. This has led to random generators, such as random `UUID.randomUUID()` and `Instant.now()` being memoized (see https://github.com/zio/zio-json/issues/1055). This PR adds an option to evaluate default parameters on-demand. See the accompanying PR for Scala 3 support: https://github.com/softwaremill/magnolia/pull/534