### PR TITLE
feat: adding on-demand default evaluation

### DIFF
--- a/core/src/main/scala/magnolia1/impl.scala
+++ b/core/src/main/scala/magnolia1/impl.scala
@@ -102,7 +102,7 @@ object CaseClassDerivation:
         paramFromMaps[Typeclass, A, p](
           label,
           CallByNeed(summonInline[Typeclass[p]]),
-          CallByNeed(defaults.get(label).flatten.flatMap(d => unsafeCast(d.apply))),
+          CallByNeed.withValueEvaluator(defaults.get(label).flatten.flatMap(d => unsafeCast(d.apply))),
           repeated,
           annotations,
           inheritedAnnotations,

--- a/core/src/main/scala/magnolia1/interface.scala
+++ b/core/src/main/scala/magnolia1/interface.scala
@@ -358,17 +358,14 @@ object SealedTrait:
 end SealedTrait
 
 object CallByNeed:
-  /**
-   * Initializes a class that allows for suspending evaluation of a value until it is needed. 
-   * Evaluation of a value via `.value` can only happen once.
-   */
+  /** Initializes a class that allows for suspending evaluation of a value until it is needed. Evaluation of a value via `.value` can only
+    * happen once.
+    */
   def apply[A](a: => A): CallByNeed[A] = new CallByNeed(() => a, () => false)
 
-  /**
-   * Initializes a class that allows for suspending evaluation of a value until it is needed. 
-   * Evaluation of a value via `.value` can only happen once.
-   * Evaluation of a value via `.valueEvaluator.map(evaluator => evaluator())` will happen every time the evaluator is called
-   */
+  /** Initializes a class that allows for suspending evaluation of a value until it is needed. Evaluation of a value via `.value` can only
+    * happen once. Evaluation of a value via `.valueEvaluator.map(evaluator => evaluator())` will happen every time the evaluator is called
+    */
   def withValueEvaluator[A](a: => A): CallByNeed[A] = new CallByNeed(() => a, () => true)
 end CallByNeed
 

--- a/core/src/main/scala/magnolia1/interface.scala
+++ b/core/src/main/scala/magnolia1/interface.scala
@@ -358,7 +358,17 @@ object SealedTrait:
 end SealedTrait
 
 object CallByNeed:
+  /**
+   * Initializes a class that allows for suspending evaluation of a value until it is needed. 
+   * Evaluation of a value via `.value` can only happen once.
+   */
   def apply[A](a: => A): CallByNeed[A] = new CallByNeed(() => a, () => false)
+
+  /**
+   * Initializes a class that allows for suspending evaluation of a value until it is needed. 
+   * Evaluation of a value via `.value` can only happen once.
+   * Evaluation of a value via `.valueEvaluator.map(evaluator => evaluator())` will happen every time the evaluator is called
+   */
   def withValueEvaluator[A](a: => A): CallByNeed[A] = new CallByNeed(() => a, () => true)
 end CallByNeed
 

--- a/core/src/main/scala/magnolia1/interface.scala
+++ b/core/src/main/scala/magnolia1/interface.scala
@@ -42,6 +42,7 @@ object CaseClass:
       *   default argument value, if any
       */
     def default: Option[PType]
+
     /** provides a function to evaluate the default value for this parameter, as defined in the case class constructor */
     def evaluateDefault: Option[() => PType] = None
     def inheritedAnnotations: IArray[Any] = IArray.empty[Any]

--- a/core/src/main/scala/magnolia1/interface.scala
+++ b/core/src/main/scala/magnolia1/interface.scala
@@ -42,6 +42,7 @@ object CaseClass:
       *   default argument value, if any
       */
     def default: Option[PType]
+    /** provides a function to evaluate the default value for this parameter, as defined in the case class constructor */
     def evaluateDefault: Option[() => PType] = None
     def inheritedAnnotations: IArray[Any] = IArray.empty[Any]
     override def toString: String = s"Param($label)"
@@ -374,6 +375,7 @@ end CallByNeed
 final class CallByNeed[+A] private (private[this] var eval: () => A, private var supportDynamicValueEvaluation: () => Boolean)
     extends Serializable {
 
+  // This second constructor is necessary to support backwards compatibility for v1.3.6 and earlier
   def this(eval: () => A) = this(eval, () => false)
 
   val valueEvaluator: Option[() => A] = {

--- a/core/src/main/scala/magnolia1/magnolia.scala
+++ b/core/src/main/scala/magnolia1/magnolia.scala
@@ -1,10 +1,6 @@
 package magnolia1
 
-import scala.compiletime.*
 import scala.deriving.Mirror
-import scala.reflect.*
-
-import Macro.*
 
 trait CommonDerivation[TypeClass[_]]:
   type Typeclass[T] = TypeClass[T]

--- a/examples/src/main/scala/magnolia1/examples/default.scala
+++ b/examples/src/main/scala/magnolia1/examples/default.scala
@@ -22,16 +22,14 @@ object HasDefault extends AutoDerivation[HasDefault]:
       }
 
       override def getDynamicDefaultValueForParam(paramLabel: String): Option[Any] =
-        val arr = IArray.genericWrapArray {
-          ctx.params
-            .filter(_.label == paramLabel)
-        }.toArray
-
-        val res = arr.headOption
+        IArray
+          .genericWrapArray {
+            ctx.params
+              .filter(_.label == paramLabel)
+          }
+          .toArray
+          .headOption
           .flatMap(_.evaluateDefault.map(res => res()))
-        println("Printing res:")
-        println(res.mkString("Array(", ", ", ")"))
-        res
     }
 
   /** chooses which subtype to delegate to */

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,5 @@ addSbtPlugin(
 )
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,5 @@ addSbtPlugin(
 )
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.1")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")

--- a/test/src/test/scala/magnolia1/tests/DefaultValuesTests.scala
+++ b/test/src/test/scala/magnolia1/tests/DefaultValuesTests.scala
@@ -37,6 +37,19 @@ class DefaultValuesTests extends munit.FunSuite:
     assertEquals(res, Right(Item("", 1, 0)))
   }
 
+  test("access dynamic default constructor values") {
+    val res1 = summon[HasDefault[ParamsWithDynamicDefault]].getDynamicDefaultValueForParam("a")
+    val res2 = summon[HasDefault[ParamsWithDynamicDefault]].getDynamicDefaultValueForParam("a")
+
+    assertEquals(res1.isDefined, true)
+    assertEquals(res2.isDefined, true)
+
+    for {
+      default1 <- res1
+      default2 <- res2
+    } yield assertNotEquals(default1, default2)
+  }
+
   test("construct a HasDefault instance for a generic product with default values") {
     val res = HasDefault.derived[ParamsWithDefaultGeneric[String, Int]].defaultValue
     assertEquals(res, Right(ParamsWithDefaultGeneric("A", 0)))
@@ -51,6 +64,8 @@ class DefaultValuesTests extends munit.FunSuite:
 object DefaultValuesTests:
 
   case class ParamsWithDefault(a: Int = 3, b: Int = 4)
+
+  case class ParamsWithDynamicDefault(a: Double = scala.math.random())
 
   case class ParamsWithDefaultGeneric[A, B](a: A = "A", b: B = "B")
 


### PR DESCRIPTION
## Description
Currently, all default values are precompiled. This has led to random generators, such as random `UUID.randomUUID()` and `Instant.now()` being memoized (see https://github.com/zio/zio-json/issues/1055). This PR adds an option to evaluate default parameters on-demand. See the accompanying PR for Scala 2 support: https://github.com/softwaremill/magnolia/pull/533