### PR TITLE
uncomment and fix java annotation tests

### DIFF
--- a/core/src/main/scala/magnolia1/macro.scala
+++ b/core/src/main/scala/magnolia1/macro.scala
@@ -278,7 +278,7 @@ object Macro:
 
     private def filterAnnotation(a: Term): Boolean =
       scala.util.Try(a.tpe <:< TypeRepr.of[scala.annotation.Annotation]).toOption.contains(true) &&
-      (a.tpe.typeSymbol.maybeOwner.isNoSymbol ||
-        (a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" &&
-          a.tpe.typeSymbol.owner.fullName != "jdk.internal"))
+        (a.tpe.typeSymbol.maybeOwner.isNoSymbol ||
+          (a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" &&
+            a.tpe.typeSymbol.owner.fullName != "jdk.internal"))
   }

--- a/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
+++ b/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
@@ -74,17 +74,15 @@ class AnnotationsTests extends munit.FunSuite:
     assertEquals(subtypeAnnotations(1).mkString, "MyAnnotation(2)")
   }
 
-// TODO - not compiling
-// test("serialize case class with Java annotations by skipping them") {
-//   val res = Show.derived[MyDto].show(MyDto("foo", 42))
-//   assertEquals(res, "MyDto{MyAnnotation(0)}(foo=foo,bar=42)")
-// }
+  test("serialize case class with Java annotations by skipping them") {
+    val res = Show.derived[MyDto].show(MyDto("foo", 42))
+    assertEquals(res, "MyDto{MyAnnotation(0)}(foo=foo,bar=42)")
+  }
 
-// TODO - not compiling
-// test("serialize case class with Java annotations which comes from external module by skipping them") {
-//   val res = Show.derived[JavaAnnotatedCase].show(JavaAnnotatedCase(1))
-//   assertEquals(res, "JavaAnnotatedCase(v=1)")
-// }
+  test("serialize case class with Java annotations which comes from external module by skipping them") {
+    val res = Show.derived[JavaAnnotatedCase].show(JavaAnnotatedCase(1))
+    assertEquals(res, "JavaAnnotatedCase(v=1)")
+  }
 
 object AnnotationsTests:
 


### PR DESCRIPTION
I'm not sure if this is somehow a really stupid way of doing it, but it seems to fix the tests, as well as some of my downstream issues *. Changing the type of the collected annotations without changing the api is probably dumb, but I figured it signalled intent without breaking any compatibility. It's not really necessary is it. Well anyway let me know your thoughts.

\* I say 'some', because there's still an issue with scala annotations - I think it happens if you annotate both a case class and a parent trait with the same annotation, but with this change I don't have to worry about that problem because I can just use the upstream java annotations instead of trying to work around the issue. Might make a follow-up at some point...