### PR TITLE
Fix failure to derive typeclass for large sum types on Scala 3

### DIFF
--- a/core/src/main/scala/magnolia1/impl.scala
+++ b/core/src/main/scala/magnolia1/impl.scala
@@ -184,17 +184,19 @@ trait SealedTraitDerivation:
 
   protected transparent inline def subtypesFromMirror[A, SubtypeTuple <: Tuple](
       m: Mirror.SumOf[A],
-      idx: Int = 0 // no longer used, kept for bincompat
+      idx: Int = 0, // no longer used, kept for bincompat
+      result: List[SealedTrait.Subtype[Typeclass, A, _]] = Nil
   ): List[SealedTrait.Subtype[Typeclass, A, _]] =
     inline erasedValue[SubtypeTuple] match
       case _: EmptyTuple =>
-        Nil
+        result.distinctBy(_.typeInfo).sortBy(_.typeInfo.full)
       case _: (s *: tail) =>
         val sub = summonFrom {
           case mm: Mirror.SumOf[`s`] =>
             subtypesFromMirror[A, mm.MirroredElemTypes](
               mm.asInstanceOf[m.type],
-              0
+              0,
+              Nil
             )
           case _ => {
             val tc = new SerializableFunction0[Typeclass[s]]:
@@ -221,5 +223,5 @@ trait SealedTraitDerivation:
             )
           }
         }
-        (sub ::: subtypesFromMirror[A, tail](m, idx + 1)).distinctBy(_.typeInfo).sortBy(_.typeInfo.full)
+        subtypesFromMirror[A, tail](m, idx + 1, sub ::: result)
 end SealedTraitDerivation


### PR DESCRIPTION
This should resolve issue #565 by making `subtypesFromMirror` tail-recursive. It doesn't use the `@tailrec` annotation however, just as the example code linked in the issue, because this isn't possible with inline methods. I hope that it does indeed fix the problem... I basically just followed the suggestions from the issue.