### PR TITLE
Avoid recursive inlining (for products)

### DIFF
--- a/core/src/main/scala/magnolia1/impl.scala
+++ b/core/src/main/scala/magnolia1/impl.scala
@@ -96,6 +96,18 @@ object CaseClassDerivation:
       } { params => product.fromProduct(Tuple.fromArray(params)) }
     }
 
+  private trait ParamFactory[TC[_], P]:
+    def tc: SerializableFunction0[TC[P]]
+    def isType(v: Any): Boolean
+
+  private object ParamFactory:
+    inline given paramFactory[TC[_], P]: ParamFactory[TC, P] =
+      new ParamFactory[TC, P]:
+        def tc: SerializableFunction0[TC[P]] =
+          new SerializableFunction0[TC[P]]:
+            def apply(): TC[P] = summonInline[TC[P]]
+        def isType(v: Any): Boolean = (v: @unchecked).isInstanceOf[P]
+
   inline def paramsFromMaps[Typeclass[_], A, Labels <: Tuple, Params <: Tuple](
       annotations: Map[String, List[Any]],
       inheritedAnnotations: Map[String, List[Any]],
@@ -104,43 +116,36 @@ object CaseClassDerivation:
       defaults: Map[String, Option[() => Any]],
       idx: Int = 0
   ): List[CaseClass.Param[Typeclass, A]] =
-    inline erasedValue[(Labels, Params)] match
-      case _: (EmptyTuple, EmptyTuple) =>
-        Nil
-      case _: ((l *: ltail), (p *: ptail)) =>
-        val label = constValue[l].asInstanceOf[String]
-        val tc = new SerializableFunction0[Typeclass[p]]:
-          override def apply(): Typeclass[p] = summonInline[Typeclass[p]]
+    val labels: List[String] =
+      summonAll[Tuple.Map[Labels, ValueOf]].toList.asInstanceOf[List[ValueOf[? <: String]]].map(_.value)
+    type PFactory[P] = ParamFactory[Typeclass, P]
+    val factories: List[PFactory[?]] =
+      summonAll[Tuple.Map[Params, PFactory]].toList.asInstanceOf[List[PFactory[?]]]
+    labels.zip(factories).zipWithIndex.map {
+      case ((label, f: PFactory[p]), i) =>
         val d =
           defaults(label) match {
             case Some(evaluator) =>
               new SerializableFunction0[Option[p]]:
                 override def apply(): Option[p] =
                   val v = evaluator()
-                  if ((v: @unchecked).isInstanceOf[p]) Some(v.asInstanceOf[p])
+                  if (f.isType(v)) Some(v.asInstanceOf[p])
                   else None
             case _ =>
               new SerializableFunction0[Option[p]]:
                 override def apply(): Option[p] = None
           }
         paramFromMaps[Typeclass, A, p](
-          label,
-          CallByNeed.createLazy(tc),
-          CallByNeed.createValueEvaluator(d),
-          repeated,
-          annotations,
-          inheritedAnnotations,
-          typeAnnotations,
-          idx
-        ) ::
-          paramsFromMaps[Typeclass, A, ltail, ptail](
+            label,
+            CallByNeed.createLazy(f.tc),
+            CallByNeed.createValueEvaluator(d),
+            repeated,
             annotations,
             inheritedAnnotations,
             typeAnnotations,
-            repeated,
-            defaults,
-            idx + 1
+            idx + i
           )
+    }
 
   private def paramFromMaps[Typeclass[_], A, p](
       label: String,

--- a/core/src/main/scala/magnolia1/impl.scala
+++ b/core/src/main/scala/magnolia1/impl.scala
@@ -121,30 +121,29 @@ object CaseClassDerivation:
     type PFactory[P] = ParamFactory[Typeclass, P]
     val factories: List[PFactory[?]] =
       summonAll[Tuple.Map[Params, PFactory]].toList.asInstanceOf[List[PFactory[?]]]
-    labels.zip(factories).zipWithIndex.map {
-      case ((label, f: PFactory[p]), i) =>
-        val d =
-          defaults(label) match {
-            case Some(evaluator) =>
-              new SerializableFunction0[Option[p]]:
-                override def apply(): Option[p] =
-                  val v = evaluator()
-                  if (f.isType(v)) Some(v.asInstanceOf[p])
-                  else None
-            case _ =>
-              new SerializableFunction0[Option[p]]:
-                override def apply(): Option[p] = None
-          }
-        paramFromMaps[Typeclass, A, p](
-            label,
-            CallByNeed.createLazy(f.tc),
-            CallByNeed.createValueEvaluator(d),
-            repeated,
-            annotations,
-            inheritedAnnotations,
-            typeAnnotations,
-            idx + i
-          )
+    labels.zip(factories).zipWithIndex.map { case ((label, f: PFactory[p]), i) =>
+      val d =
+        defaults(label) match {
+          case Some(evaluator) =>
+            new SerializableFunction0[Option[p]]:
+              override def apply(): Option[p] =
+                val v = evaluator()
+                if (f.isType(v)) Some(v.asInstanceOf[p])
+                else None
+          case _ =>
+            new SerializableFunction0[Option[p]]:
+              override def apply(): Option[p] = None
+        }
+      paramFromMaps[Typeclass, A, p](
+        label,
+        CallByNeed.createLazy(f.tc),
+        CallByNeed.createValueEvaluator(d),
+        repeated,
+        annotations,
+        inheritedAnnotations,
+        typeAnnotations,
+        idx + i
+      )
     }
 
   private def paramFromMaps[Typeclass[_], A, p](


### PR DESCRIPTION
Leverage summonAll to avoid recursive inlining as proposed in #574

So far, this is just a proof of concept.

Various tests are still failing - most of them are related to error messages of compilation errors not being as expected, but
one (["derive instances for types with refined types if implicit provided"](https://github.com/softwaremill/magnolia/blob/44422700e0fbfc7ccb8dc6ff54880edf181e7cdf/test/src/test/scala/magnolia1/tests/OtherTests.scala#L41)) seems a bit more serious (compilation fails when it shouldn't).