### PR TITLE
Use latest LTS 3.3.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.softwaremill.UpdateVersionInDocs
 import com.softwaremill.SbtSoftwareMillCommon.commonSmlBuildSettings
 import com.softwaremill.Publish.{updateDocs, ossPublishSettings}
 
-val scala3 = "3.3.3"
+val scala3 = "3.3.5"
 
 ThisBuild / dynverTagPrefix := "scala3-v" // a custom prefix is needed to differentiate tags between scala2 & scala3 versions
 


### PR DESCRIPTION
I discovered that magnolia compiled by 3.3.3 (or 3.3.4) causes

https://github.com/scala/scala3/issues/22499

which is due to a tree with `NoSpan`. I believe it is the `Ident` in this `unchecked` annotation:

https://github.com/softwaremill/magnolia/blob/scala3/core/src/main/scala/magnolia1/impl.scala#L120

I have verified that a couple of the projects erroring at the ticket (which depend directly or indirectly on magnolia) work after just publishing locally with 3.3.5. (That is, a project using 3.7 consuming magnolia built by 3.3.5.)

Sorry I haven't yet nailed down what the fix is on 3.3.5.

The symptom is that on 3.7 `-Wunused:imports` uses the span but must code defensively. I don't know yet whether it's strictly a bug that a tree has a position that has no span. The defensive fix is at

https://github.com/scala/scala3/pull/22504