### PR TITLE
More efficient evaluation of default values

### DIFF
--- a/core/src/main/scala/magnolia1/impl.scala
+++ b/core/src/main/scala/magnolia1/impl.scala
@@ -117,11 +117,10 @@ object CaseClassDerivation:
               new SerializableFunction0[Option[p]]:
                 override def apply(): Option[p] =
                   val v = evaluator()
-                  if ((v: @unchecked).isInstanceOf[p]) Some(v.asInstanceOf[p])
+                  if ((v: @unchecked).isInstanceOf[p]) new Some(v).asInstanceOf[Option[p]]
                   else None
             case _ =>
-              new SerializableFunction0[Option[p]]:
-                override def apply(): Option[p] = None
+              returningNone.asInstanceOf[SerializableFunction0[Option[p]]]
           }
         paramFromMaps[Typeclass, A, p](
           label,
@@ -162,6 +161,10 @@ object CaseClassDerivation:
       IArray.from(inheritedAnnotations.getOrElse(label, List())),
       IArray.from(typeAnnotations.getOrElse(label, List()))
     )
+
+  private val returningNone =
+    new SerializableFunction0[Option[Any]]:
+      override def apply(): Option[Any] = None
 
 end CaseClassDerivation
 


### PR DESCRIPTION
Avoids redundant `BoxedRunTime.boxing*`, `BoxedRunTime.unbox*`, and `Some.apply` calls for each evaluated default value.

Below are decompiled `apply` implementations of the evaluation function generated by the magnolia library.

Before:
```java
public Option apply() {
    Object v = this.evaluator$1.apply();
    return (Option)(v instanceof Integer ? scala.Some..MODULE$.apply(BoxesRunTime.boxToInteger(BoxesRunTime.unboxToInt(v))) : scala.None..MODULE$);
}
```

After:
```java
public Option apply() {
    Object v = this.evaluator$1.apply();
    return (Option)(v instanceof Integer ? new Some(v) : scala.None..MODULE$);
}
```

Also, this change reuses the same instance of the evaluator function that always produces `None` that greatly reduces size of generated classes, as in a code snippet for one default value below.

Before:
```java
} else {
    var1995 = new SerializableFunction0<Option<Object>>() {
        // $FF: synthetic method
        // $FF: bridge method
        public String toString() {
            return Function0.toString$(this);
        }

        // $FF: synthetic method
        // $FF: bridge method
        public byte apply$mcB$sp() {
            return Function0.apply$mcB$sp$(this);
        }

        // $FF: synthetic method
        // $FF: bridge method
        public short apply$mcS$sp() {
            return Function0.apply$mcS$sp$(this);
        }

        // $FF: synthetic method
        // $FF: bridge method
        public char apply$mcC$sp() {
            return Function0.apply$mcC$sp$(this);
        }

        // $FF: synthetic method
        // $FF: bridge method
        public int apply$mcI$sp() {
            return Function0.apply$mcI$sp$(this);
        }

        // $FF: synthetic method
        // $FF: bridge method
        public long apply$mcJ$sp() {
            return Function0.apply$mcJ$sp$(this);
        }

        // $FF: synthetic method
        // $FF: bridge method
        public float apply$mcF$sp() {
            return Function0.apply$mcF$sp$(this);
        }

        // $FF: synthetic method
        // $FF: bridge method
        public double apply$mcD$sp() {
            return Function0.apply$mcD$sp$(this);
        }

        // $FF: synthetic method
        // $FF: bridge method
        public void apply$mcV$sp() {
            Function0.apply$mcV$sp$(this);
        }

        // $FF: synthetic method
        // $FF: bridge method
        public boolean apply$mcZ$sp() {
            return Function0.apply$mcZ$sp$(this);
        }

        public Option apply() {
            return scala.None..MODULE$;
        }

        // $FF: synthetic method
        // $FF: bridge method
        public Object apply() {
            return this.apply();
        }
    };
```

After:
```java
} else {
    var1995 = magnolia1.CaseClassDerivation..MODULE$.inline$returningNone();
}
```