### PR TITLE
fix annotations and inherited annotations not being found for Scala 3 parameterless enum cases

### DIFF
--- a/core/src/main/scala/magnolia1/macro.scala
+++ b/core/src/main/scala/magnolia1/macro.scala
@@ -180,17 +180,18 @@ object Macro:
 
     def anns: Expr[List[scala.annotation.Annotation]] =
       Expr.ofList {
-        tpe.typeSymbol.annotations
+        annotatedSymbol.annotations
           .filter(filterAnnotation)
           .map(_.asExpr.asInstanceOf[Expr[scala.annotation.Annotation]])
       }
 
     def inheritedAnns: Expr[List[scala.annotation.Annotation]] =
       Expr.ofList {
+        val self = annotatedSymbol
         tpe.baseClasses
           .filterNot(isObjectOrScala)
           .collect {
-            case s if s != tpe.typeSymbol => s.annotations
+            case s if s != self => s.annotations
           } // skip self
           .flatten
           .filter(filterAnnotation)
@@ -281,4 +282,9 @@ object Macro:
         (a.tpe.typeSymbol.maybeOwner.isNoSymbol ||
           (a.tpe.typeSymbol.owner.fullName != "scala.annotation.internal" &&
             a.tpe.typeSymbol.owner.fullName != "jdk.internal"))
+
+    // A parameterless enum case is stored in a val and needs to be resolved as term, other cases are resolved as type
+    private def annotatedSymbol: Symbol =
+      if !tpe.termSymbol.isNoSymbol && !tpe.typeSymbol.flags.is(Flags.Module) then tpe.termSymbol else tpe.typeSymbol
+
   }

--- a/examples/src/main/scala/magnolia1/examples/SubtypeInfo.scala
+++ b/examples/src/main/scala/magnolia1/examples/SubtypeInfo.scala
@@ -5,7 +5,11 @@ import magnolia1._
 trait SubtypeInfo[T] {
   def subtypeIsObject: Seq[Boolean]
   def traitAnnotations: Seq[Any]
+  def traitInheritedAnnotations: Seq[Any]
+  def traitTypeAnnotations: Seq[Any]
   def subtypeAnnotations: Seq[Seq[Any]]
+  def subtypeInheritedAnnotations: Seq[Seq[Any]]
+  def subtypeTypeAnnotations: Seq[Seq[Any]]
   def isEnum: Boolean
 }
 
@@ -14,20 +18,34 @@ object SubtypeInfo extends Derivation[SubtypeInfo]:
     new SubtypeInfo[T]:
       def subtypeIsObject: Seq[Boolean] = Nil
       def traitAnnotations: List[Any] = Nil
+      def traitInheritedAnnotations: List[Any] = Nil
+      def traitTypeAnnotations: List[Any] = Nil
       def subtypeAnnotations: List[List[Any]] = Nil
+      def subtypeInheritedAnnotations: List[List[Any]] = Nil
+      def subtypeTypeAnnotations: List[List[Any]] = Nil
       def isEnum: Boolean = false
 
   override def split[T](ctx: SealedTrait[SubtypeInfo, T]): SubtypeInfo[T] =
     new SubtypeInfo[T]:
       def subtypeIsObject: Seq[Boolean] = ctx.subtypes.map(_.isObject)
       def traitAnnotations: Seq[Any] = ctx.annotations
+      def traitInheritedAnnotations: Seq[Any] = ctx.inheritedAnnotations
+      def traitTypeAnnotations: Seq[Any] = ctx.typeAnnotations
       def subtypeAnnotations: Seq[Seq[Any]] =
         ctx.subtypes.map(_.annotations.toList).toList
+      def subtypeInheritedAnnotations: Seq[Seq[Any]] =
+        ctx.subtypes.map(_.inheritedAnnotations.toList).toList
+      def subtypeTypeAnnotations: Seq[Seq[Any]] =
+        ctx.subtypes.map(_.typeAnnotations.toList).toList
       def isEnum: Boolean = ctx.isEnum
 
   given fallback[T]: SubtypeInfo[T] =
     new SubtypeInfo[T]:
       def subtypeIsObject: Seq[Boolean] = Nil
       def traitAnnotations: Seq[Any] = Nil
+      def traitInheritedAnnotations: Seq[Any] = Nil
+      def traitTypeAnnotations: Seq[Any] = Nil
       def subtypeAnnotations: Seq[Seq[Any]] = Nil
+      def subtypeInheritedAnnotations: Seq[Seq[Any]] = Nil
+      def subtypeTypeAnnotations: Seq[Seq[Any]] = Nil
       def isEnum: Boolean = false

--- a/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
+++ b/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
@@ -70,8 +70,14 @@ class AnnotationsTests extends munit.FunSuite:
 
   test("sealed trait enumeration should provide subtype annotations") {
     val subtypeAnnotations = SubtypeInfo.derived[Sport].subtypeAnnotations
-    assertEquals(subtypeAnnotations(0).mkString, "MyAnnotation(1)")
+    assertEquals(subtypeAnnotations.head.mkString, "MyAnnotation(1)")
     assertEquals(subtypeAnnotations(1).mkString, "MyAnnotation(2)")
+  }
+
+  test("sealed trait enumeration should provide subtype inherited annotations") {
+    val subtypeAnnotations = SubtypeInfo.derived[Sport].subtypeInheritedAnnotations
+    assertEquals(subtypeAnnotations.head.map(_.toString).mkString, "MyAnnotation(0)") // Boxing
+    assertEquals(subtypeAnnotations(1).map(_.toString).mkString, "MyAnnotation(0)") // Soccer
   }
 
   test("serialize case class with Java annotations by skipping them") {
@@ -82,6 +88,45 @@ class AnnotationsTests extends munit.FunSuite:
   test("serialize case class with Java annotations which comes from external module by skipping them") {
     val res = Show.derived[JavaAnnotatedCase].show(JavaAnnotatedCase(1))
     assertEquals(res, "JavaAnnotatedCase(v=1)")
+  }
+
+  test("Scala 3 enum should provide annotations on enum") {
+    val traitAnnotations = SubtypeInfo.derived[Size].traitAnnotations.map(_.toString)
+    assertEquals(traitAnnotations.mkString, "MyAnnotation(0)")
+  }
+
+  test("Scala 3 enum should provide annotations on parameterless enum cases") {
+    val subtypeAnnotations = SubtypeInfo.derived[Size].subtypeAnnotations
+    // Subtypes are sorted alphabetically by full type name
+    assertEquals(subtypeAnnotations.head.mkString, "MyAnnotation(3)") // L
+    assertEquals(subtypeAnnotations(1).mkString, "MyAnnotation(2)") // M
+    assertEquals(subtypeAnnotations(2).mkString, "MyAnnotation(1)") // S
+  }
+
+  test("Scala 3 enum should provide inherited annotations on parameterless enum cases") {
+    val inherited = SubtypeInfo.derived[Size].subtypeInheritedAnnotations
+    assertEquals(inherited.head.mkString, "MyAnnotation(0)") // L inherits from Size
+    assertEquals(inherited(1).mkString, "MyAnnotation(0)") // M inherits from Size
+    assertEquals(inherited(2).mkString, "MyAnnotation(0)") // S inherits from Size
+  }
+
+  test("Scala 3 enum case with params should provide param annotations") {
+    val show = Show.derived[Shape].show(Shape.Square(5))
+    // Square's own @MyAnnotation(3), inherited @MyAnnotation(0) from Shape, and @MyAnnotation(4) on side param
+    assertEquals(show, "{MyAnnotation(3),MyAnnotation(0)}Square{MyAnnotation(3),MyAnnotation(0)}(side{MyAnnotation(4)}=5)")
+
+    val info = SubtypeInfo.derived[Shape]
+    assertEquals(info.traitAnnotations.map(_.toString).mkString, "MyAnnotation(0)")
+    // Subtypes are sorted alphabetically by full type name
+    assertEquals(info.subtypeAnnotations.head.map(_.toString).mkString, "MyAnnotation(1)") // Circle
+    assertEquals(info.subtypeAnnotations(1).map(_.toString).mkString, "MyAnnotation(3)") // Square
+    assertEquals(info.subtypeInheritedAnnotations.head.map(_.toString).mkString, "MyAnnotation(0)") // Circle inherits from Shape
+    assertEquals(info.subtypeInheritedAnnotations(1).map(_.toString).mkString, "MyAnnotation(0)") // Square inherits from Shape
+  }
+
+  test("Scala 3 enum case with params should provide inherited param annotations") {
+    val show = Show.derived[Tagged].show(Tagged.Sized("low", 5))
+    assertEquals(show, "Sized(name=low,value{[i]MyAnnotation(10)}=5)")
   }
 
 object AnnotationsTests:
@@ -159,3 +204,27 @@ object AnnotationsTests:
       likesNuts: Boolean,
       @MyAnnotation(4) likesVeggies: Boolean
   ) extends Rodent
+
+  @MyAnnotation(0)
+  enum Size:
+    @MyAnnotation(1)
+    case S extends Size
+    @MyAnnotation(2)
+    case M extends Size
+    @MyAnnotation(3)
+    case L extends Size
+
+  @MyAnnotation(0)
+  enum Shape:
+    @MyAnnotation(1)
+    case Circle(@MyAnnotation(2) radius: Int) extends Shape
+    @MyAnnotation(3)
+    case Square(@MyAnnotation(4) side: Int) extends Shape
+
+  sealed trait HasValue:
+    def name: String
+    @MyAnnotation(10)
+    def value: Int
+
+  enum Tagged extends HasValue:
+    case Sized(name: String, value: Int) extends Tagged


### PR DESCRIPTION
Hi,

I would like to fix #491 to get annotations (and inherited annotations) on Scala 3 parameterless enum cases.

Here is my proposal to fix it. Does it look good to you?

Thanks.