### PR TITLE
Fix SealedTrait.Subtype.typeAnnotations to expose subtype's type annotations

### DIFF
--- a/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
+++ b/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
@@ -80,6 +80,11 @@ class AnnotationsTests extends munit.FunSuite:
     assertEquals(subtypeAnnotations(1).map(_.toString).mkString, "MyAnnotation(0)") // Soccer
   }
 
+  test("sealed trait enumeration should provide subtype type annotations") {
+    val subtypeTypeAnnotations = SubtypeInfo.derived[AttributeParent].subtypeTypeAnnotations
+    assertEquals(subtypeTypeAnnotations.head.map(_.toString).mkString, "MyTypeAnnotation(2)") // Attributed
+  }
+
   test("serialize case class with Java annotations by skipping them") {
     val res = Show.derived[MyDto].show(MyDto("foo", 42))
     assertEquals(res, "MyDto{MyAnnotation(0)}(foo=foo,bar=42)")


### PR DESCRIPTION
Fixes #646.

The `SealedTrait.Subtype.typeAnnotations` property currently returns the parent sealed trait's type annotations instead of the individual subtype's own type annotations.

This PR adds a failing test case (`sealed trait enumeration should provide subtype type annotations`) that demonstrates the expected behavior: when accessing `typeAnnotations` on a subtype, it should return that subtype's own type annotations (e.g., `MyTypeAnnotation(2)` for the Attributed subtype in the test) rather than the parent's `paramTypeAnns`.

Implementation of the fix is pending.

Closes softwaremill/magnolia#646.