### PR TITLE
Fix SealedTrait.Subtype.typeAnnotations to use subtype's own type annotations

### DIFF
--- a/core/src/main/scala/magnolia1/impl.scala
+++ b/core/src/main/scala/magnolia1/impl.scala
@@ -283,7 +283,7 @@ trait SealedTraitDerivation:
             typeInfo[s],
             IArray.from(anns[s]),
             IArray.from(inheritedAnns[s]),
-            IArray.from(paramTypeAnns[A]),
+            IArray.from(typeAnns[s]),
             isObject[s],
             idx,
             CallByNeed.createLazy(tc),

--- a/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
+++ b/test/src/test/scala/magnolia1/tests/AnnotationsTests.scala
@@ -80,6 +80,12 @@ class AnnotationsTests extends munit.FunSuite:
     assertEquals(subtypeAnnotations(1).map(_.toString).mkString, "MyAnnotation(0)") // Soccer
   }
 
+  test("sealed trait enumeration should provide subtype type annotations") {
+    val subtypeTypeAnnotations =
+      SubtypeInfo.derived[AttributeParent].subtypeTypeAnnotations
+    assertEquals(subtypeTypeAnnotations.head.map(_.toString).mkString, "MyTypeAnnotation(2)") // Attributed
+  }
+
   test("serialize case class with Java annotations by skipping them") {
     val res = Show.derived[MyDto].show(MyDto("foo", 42))
     assertEquals(res, "MyDto{MyAnnotation(0)}(foo=foo,bar=42)")


### PR DESCRIPTION
Fixes #646. SealedTrait.Subtype.typeAnnotations was incorrectly populated with the parent sealed trait's paramTypeAnns instead of the subtype's own typeAnns.

The fix changes the Subtype construction in SealedTraitDerivation to use typeAnns[s] (the subtype's annotations) rather than paramTypeAnns[A] (the parent's annotations).

A test has been added to verify that sealed trait enumeration now correctly provides the subtype's type annotations.

Closes softwaremill/magnolia#646.