### PR TITLE
Make Monadic[Future].point use Future.successful

### DIFF
--- a/core/src/main/scala/magnolia1/monadic.scala
+++ b/core/src/main/scala/magnolia1/monadic.scala
@@ -23,7 +23,7 @@ object Monadic:
       from.flatMap(fn)
 
   given (using ec: ExecutionContext): Monadic[Future] with
-    def point[A](value: A): Future[A] = Future(value)
+    def point[A](value: A): Future[A] = Future.successful(value)
     def map[A, B](from: Future[A])(fn: A => B): Future[B] = from.map(fn)
     def flatMap[A, B](from: Future[A])(fn: A => Future[B]): Future[B] =
       from.flatMap(fn)

--- a/test/src/test/scala/magnolia1/tests/MonadicTests.scala
+++ b/test/src/test/scala/magnolia1/tests/MonadicTests.scala
@@ -1,0 +1,20 @@
+package magnolia1.tests
+
+import magnolia1.*
+import scala.concurrent.{ExecutionContext, Future}
+
+class MonadicTests extends munit.FunSuite:
+
+  test("Monadic[Future].point lifts the value eagerly without using the ExecutionContext") {
+    // An ExecutionContext that never runs any submitted task. With this EC,
+    // Future.successful(value) is already completed, while Future(value)
+    // (which submits a task) never completes.
+    given ExecutionContext = new ExecutionContext:
+      def execute(runnable: Runnable): Unit = ()
+      def reportFailure(cause: Throwable): Unit = ()
+
+    val f = summon[Monadic[Future]].point(42)
+
+    assert(f.isCompleted, "point(value) should produce an already-completed Future")
+    assertEquals(f.value.flatMap(_.toOption), Some(42))
+  }


### PR DESCRIPTION
Fixes #647

The `point` method in `Monadic[Future]` was using `Future(value)` to lift values, which unnecessarily submits the wrapping operation as a task to the ExecutionContext. This can be problematic if the EC is unavailable or constrained.

Changed to `Future.successful(value)`, which returns an already-completed Future without requiring ExecutionContext execution. This is the idiomatic pattern for lifting already-computed values into the Future monad.

Added a test that verifies the behavior using a no-op ExecutionContext—the old implementation would never complete while the new one completes immediately.

Closes softwaremill/magnolia#647.