### PR TITLE
Preserve annotations defined on type aliases

### DIFF
--- a/core/src/main/scala/magnolia1/macro.scala
+++ b/core/src/main/scala/magnolia1/macro.scala
@@ -184,10 +184,15 @@ object Macro:
 
     def anns: Expr[List[scala.annotation.Annotation]] =
       Expr.ofList {
-        annotatedSymbol.annotations
+        (aliasAnnotations ++ annotatedSymbol.annotations)
           .filter(filterAnnotation)
           .map(_.asExpr.asInstanceOf[Expr[scala.annotation.Annotation]])
       }
+
+    // annotations on a type alias itself, e.g. @ann type T = ...
+    private def aliasAnnotations: List[Term] =
+      val aliasSymbol = TypeRepr.of[T].typeSymbol
+      if aliasSymbol != tpe.typeSymbol then aliasSymbol.annotations else Nil
 
     def inheritedAnns: Expr[List[scala.annotation.Annotation]] =
       Expr.ofList {

--- a/test/src/test/scala/magnolia1/tests/TypeAliasesTests.scala
+++ b/test/src/test/scala/magnolia1/tests/TypeAliasesTests.scala
@@ -3,6 +3,8 @@ package magnolia1.tests
 import magnolia1.*
 import magnolia1.examples.*
 
+import scala.annotation.StaticAnnotation
+
 class TypeAliasesTests extends munit.FunSuite:
   import TypeAliasesTests.*
   test("show a type aliased case class") {
@@ -21,6 +23,12 @@ class TypeAliasesTests extends munit.FunSuite:
   test("opaques should remain opaque") {
     assertEquals(Nil, Macro.defaultValue[OpaqueA])
   }
+  test("collect annotations from a union type alias") {
+    assertEquals(Macro.anns[AnnotatedUnion].map(_.toString), List("MyAnnotation(0)"))
+  }
+  test("combine annotations on a type alias with those on the dealiased type") {
+    assertEquals(Macro.anns[AnnotatedAlias].map(_.toString), List("MyAnnotation(1)", "MyAnnotation(2)"))
+  }
 end TypeAliasesTests
 object TypeAliasesTests:
   sealed trait Entity
@@ -37,4 +45,15 @@ object TypeAliasesTests:
   case class A(i: Int = 1)
   opaque type OpaqueA = A
   type AliasA = A
+
+  case class MyAnnotation(order: Int) extends StaticAnnotation
+
+  @MyAnnotation(0)
+  type AnnotatedUnion = Company | Person
+
+  @MyAnnotation(2)
+  case class B(i: Int)
+
+  @MyAnnotation(1)
+  type AnnotatedAlias = B
 end TypeAliasesTests


### PR DESCRIPTION
## Problem

#662 (released in 1.3.22) dealiases the `TypeRepr` before collecting annotations, which dropped annotations placed on the type alias itself. This broke Caliban's annotated union type aliases (see the [failed build](https://github.com/ghostdogpr/caliban/pull/3058) and [this comment](https://github.com/softwaremill/magnolia/pull/662#issuecomment-4964831050)):

```scala
@GQLName("Payload2")
@GQLDescription("Union type Payload")
type Payload = Foo | Bar | Baz
```

`Macro.anns[Payload]` returned `Nil` on 1.3.22, whereas 1.3.21 returned the alias's annotations.

## Fix

`CollectAnnotations.anns` now collects the annotations of the pre-dealias alias symbol and combines them with those of the dealiased type (alias annotations first). For non-alias types the symbols are identical, so behavior is unchanged; opaque types are unaffected since `.dealias` doesn't unwrap them.

Notes on scope:
- Chained aliases (`type A2 = A1; type A1 = B` with annotations on `A1`) only pick up the outermost alias's annotations — there's no one-step dealias in the reflection API.
- Only `anns` is extended; `inheritedAnns`/`typeAnns`/`paramAnns` are left as-is.

## Tests

Two new tests in `TypeAliasesTests`: one reproducing the Caliban break (annotated union type alias), one checking that alias annotations are combined with those on the dealiased type. Both fail without the fix; full suite passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)