### PR TITLE
more stable tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,10 @@ lazy val test = (projectMatrix in file("test"))
     projectDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "1.0.0-M12"
     ),
+    scalacOptions ++= List(
+      "-pagewidth",
+      "80",
+    ),
     testFrameworks += new TestFramework("munit.Framework"),
     publishArtifact := false
   )

--- a/test/src/test/scala/magnolia1/tests/OtherTests.scala
+++ b/test/src/test/scala/magnolia1/tests/OtherTests.scala
@@ -34,7 +34,7 @@ class OtherTests extends munit.FunSuite:
     assert(
       clue(
         error
-      ) contains "No given instance of type magnolia1.examples.Show[String"
+      ) contains "No given instance of type magnolia1.examples.Show[String, Long & magnolia1.tests.OtherTests.Character.Tag] was found."
     )
   }
 

--- a/test/src/test/scala/magnolia1/tests/ProductsTests.scala
+++ b/test/src/test/scala/magnolia1/tests/ProductsTests.scala
@@ -201,7 +201,7 @@ class ProductsTests extends munit.FunSuite:
   test("show chained error stack when leaf instance is missing") {
     val error = compileErrors("Show.derived[Schedule]")
     assert(
-      clue(error) contains "No given instance of type magnolia1.examples.Show[String"
+      clue(error) contains "No given instance of type magnolia1.examples.Show[String, Seq[magnolia1.tests.ProductsTests.Event]] was found."
     )
   }
 


### PR DESCRIPTION
ensure tests don't depend on terminal settings
remove workaround for https://github.com/scalameta/munit/issues/1119